### PR TITLE
Implement Sprint 1 ingestion pipeline

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,16 @@
 .PHONY: dev test graph pull-models
 
 dev:
-@echo "Starting services and installing dependencies..."
+	@echo "Starting services and installing dependencies..."
 
 # run pytest in quiet mode
 test:
-pytest -q
+	pytest -q
 
 # placeholder for graph visualization
 graph:
-@echo "Generating graph diagram..."
+	@echo "Generating graph diagram..."
 
 # pull models for offline use
 pull-models:
-@echo "Pulling models for offline use..."
+	@echo "Pulling models for offline use..."

--- a/README.md
+++ b/README.md
@@ -8,3 +8,14 @@ This repository contains notes and guides for building an on-premise LangGraph-b
 - [TASKS.md](TASKS.md) – canonical task model
 
 Use `make dev` to start services and install dependencies. See `DEV_ENV.md` for details.
+
+## Ingestion
+The `ingestion` package contains an offline script for loading data into Qdrant. It supports Gmail messages and local files.
+
+Run it with:
+
+```bash
+python -m ingestion.ingest --gmail-query "is:inbox" --directory ./docs
+```
+
+The script splits documents with `RecursiveCharacterTextSplitter`, generates embeddings via the local Ollama model, and stores them in the `ingestion` collection in Qdrant.

--- a/ingestion/__init__.py
+++ b/ingestion/__init__.py
@@ -1,0 +1,4 @@
+"""Ingestion package."""
+from .ingest import ingest
+from .loaders import load_gmail, load_files
+__all__ = ["ingest", "load_gmail", "load_files"]

--- a/ingestion/ingest.py
+++ b/ingestion/ingest.py
@@ -1,0 +1,54 @@
+"""Ingestion script for populating Qdrant with local data and emails."""
+from __future__ import annotations
+
+import os
+from typing import Iterable, List
+
+from langchain_text_splitters import RecursiveCharacterTextSplitter
+from langchain_community.embeddings import OllamaEmbeddings
+from langchain_community.vectorstores import Qdrant
+from qdrant_client import QdrantClient
+
+from .loaders import load_gmail, load_files
+
+
+CHUNK_SIZE = 1000
+CHUNK_OVERLAP = 200
+
+
+def get_text_chunks(docs: Iterable) -> List[str]:
+    splitter = RecursiveCharacterTextSplitter(chunk_size=CHUNK_SIZE, chunk_overlap=CHUNK_OVERLAP)
+    return [chunk.page_content for chunk in splitter.split_documents(list(docs))]
+
+
+def ingest(gmail_query: str | None = None, directory: str | None = None) -> None:
+    """Run the ingestion pipeline."""
+    documents = []
+    if gmail_query:
+        documents.extend(load_gmail(gmail_query))
+    if directory:
+        documents.extend(load_files(directory))
+
+    if not documents:
+        print("No documents loaded")
+        return
+
+    texts = get_text_chunks(documents)
+
+    embeddings = OllamaEmbeddings()
+    client = QdrantClient(url=os.environ.get("QDRANT_URL", "http://localhost:6333"))
+    vectorstore = Qdrant(client=client, collection_name="ingestion", embeddings=embeddings)
+
+    ids = vectorstore.add_texts(texts)
+    print(f"Stored {len(ids)} chunks in Qdrant collection 'ingestion'")
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Run ingestion")
+    parser.add_argument("--gmail-query", help="Gmail search query", default=None)
+    parser.add_argument("--directory", help="Directory of files to ingest", default=None)
+    args = parser.parse_args()
+
+    ingest(args.gmail_query, args.directory)

--- a/ingestion/loaders.py
+++ b/ingestion/loaders.py
@@ -1,0 +1,30 @@
+"""Data loader utilities for the ingestion pipeline."""
+from __future__ import annotations
+
+from typing import List
+
+from langchain_google_community import GMailLoader
+from langchain_community.document_loaders import DirectoryLoader
+from langchain_core.documents import Document
+
+
+def load_gmail(query: str | None = None, *, label: str | None = None, max_results: int = 10) -> List[Document]:
+    """Load messages from Gmail using the Google Community loader.
+
+    Parameters
+    ----------
+    query : str, optional
+        Gmail search query string.
+    label : str, optional
+        Restrict results to a specific label.
+    max_results : int, default 10
+        Limit the number of fetched messages.
+    """
+    loader = GMailLoader(query=query, label_ids=[label] if label else None, num_results=max_results)
+    return loader.load()
+
+
+def load_files(path: str) -> List[Document]:
+    """Load documents from a local directory."""
+    loader = DirectoryLoader(path)
+    return loader.load()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,6 @@
 langchain
+langchain-core
+langchain-text-splitters
 langgraph
 langchain-openai
 langchain-community

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ langchain
 langgraph
 langchain-openai
 langchain-community
+langchain-google-community
 ollama
 qdrant-client
 langfuse

--- a/tasks.yml
+++ b/tasks.yml
@@ -1,0 +1,15 @@
+- id: sprint1_ingestion
+  description: Build the ingestion pipeline using Gmail and filesystem loaders, split text, generate embeddings, and store them in Qdrant.
+  status: todo
+- id: sprint2_retrieval
+  description: Integrate Qdrant retrieval using hybrid search to answer questions from stored documents.
+  status: todo
+- id: sprint3_tool_execution
+  description: Add GmailToolkit and GoogleCalendarToolkit to enable the agent to send drafts and schedule events.
+  status: todo
+- id: extend_pkg
+  description: Extend retrieval with a Personal Knowledge Graph powered by LLMGraphTransformer.
+  status: todo
+- id: improve_task_management
+  description: Improve task management with deterministic rules, LLM prioritization, and human-in-the-loop reflection.
+  status: todo

--- a/tasks.yml
+++ b/tasks.yml
@@ -1,6 +1,6 @@
 - id: sprint1_ingestion
   description: Build the ingestion pipeline using Gmail and filesystem loaders, split text, generate embeddings, and store them in Qdrant.
-  status: todo
+  status: done
 - id: sprint2_retrieval
   description: Integrate Qdrant retrieval using hybrid search to answer questions from stored documents.
   status: todo

--- a/tests/test_ingestion.py
+++ b/tests/test_ingestion.py
@@ -1,0 +1,28 @@
+import os, sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from unittest.mock import patch, MagicMock
+
+from ingestion import ingest
+from ingestion.ingest import get_text_chunks
+
+
+def test_get_text_chunks():
+    from langchain_core.documents import Document
+    docs = [Document(page_content="a" * 1500)]
+    chunks = get_text_chunks(docs)
+    assert len(chunks) > 1
+
+
+def test_ingest_pipeline():
+    from langchain_core.documents import Document
+    fake_doc = Document(page_content="hello world")
+    with patch("ingestion.ingest.load_gmail", return_value=[fake_doc]) as lg, \
+         patch("ingestion.ingest.load_files", return_value=[fake_doc]) as lf, \
+         patch("ingestion.ingest.OllamaEmbeddings") as embed, \
+         patch("ingestion.ingest.Qdrant") as qdrant:
+        mock_vs = MagicMock()
+        qdrant.return_value = mock_vs
+        mock_vs.add_texts.return_value = ["1"]
+        ingest("test", "./data")
+        assert mock_vs.add_texts.called


### PR DESCRIPTION
## Summary
- add roadmap tasks in `tasks.yml`
- create `ingestion` package with Gmail and file loaders
- implement `ingest.py` script to chunk and store data in Qdrant
- document ingestion in `README`
- add dependencies for gmail loader
- include tests for ingestion pipeline

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6858c8aa1c94832a9f4a8d2dd760654c