### PR TITLE
Sprint 4 PKG and graph-based planning

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,4 +57,8 @@ For manual validation, follow these sprint-specific checks:
    - Inspect Langfuse traces to see the `retrieve_context` node outputs.
 4. **Sprint 3 – Action Engine (Tools)**
    - Use `tool_agent.py` to schedule a calendar event and draft an email. Confirm the actions in Google Calendar and Gmail Drafts.
+5. **Sprint 4 – Personal Knowledge Graph**
+   - Run `ingestion/build_pkg.py` and verify a Langfuse trace was recorded.
+   - Inspect Neo4j to confirm `Person`, `Company`, and `Project` nodes exist.
+   - Query `rag_agent.py` and check that answers reference these entities.
 

--- a/agent/__init__.py
+++ b/agent/__init__.py
@@ -1,0 +1,1 @@
+from .nodes import plan_step, retrieve_context, AgentState

--- a/agent/nodes.py
+++ b/agent/nodes.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+"""Agent nodes with PKG-aware planning and retrieval."""
+from typing import List, Dict, TypedDict, Any
+
+from langchain_core.messages import BaseMessage, HumanMessage, AIMessage
+from langchain_community.chat_models import ChatOllama
+from langchain_community.embeddings import OllamaEmbeddings
+from langchain_community.vectorstores import Qdrant
+from qdrant_client import QdrantClient
+from neo4j import GraphDatabase
+
+
+class AgentState(TypedDict, total=False):
+    messages: List[BaseMessage]
+    tasks: List[str]
+    context_docs: List[str]
+    graph_metadata: List[Dict[str, Any]]
+
+
+# --- PKG Query Helpers ---------------------------------------------------------
+
+
+def _query_pkg(query: str) -> tuple[list[str], list[dict]]:
+    """Return related document IDs and metadata from the graph."""
+    driver = GraphDatabase.driver("bolt://localhost:7687", auth=("neo4j", "password"))
+    with driver.session() as session:
+        result = session.run(
+            """
+            MATCH (d:Document)-[r]->(e)
+            WHERE toLower(e.name) CONTAINS toLower($q)
+            RETURN d.id AS id, e.name AS entity
+            LIMIT 10
+            """,
+            q=query,
+        )
+        data = []
+        for record in result:
+            entity = record.get("entity")
+            doc_id = record.get("id")
+            item = {"entity": entity}
+            if doc_id is not None:
+                item["doc_id"] = doc_id
+            data.append(item)
+    doc_ids = [d["doc_id"] for d in data if "doc_id" in d]
+    return doc_ids, data
+
+
+# --- Vector Retriever ----------------------------------------------------------
+
+
+def _build_retriever() -> any:
+    client = QdrantClient(url="http://localhost:6333")
+    vectorstore = Qdrant(
+        client=client,
+        collection_name="ingestion",
+        embeddings=OllamaEmbeddings(),
+    )
+    return vectorstore.as_retriever()
+
+
+retriever = _build_retriever()
+
+
+# --- Nodes --------------------------------------------------------------------
+
+
+def retrieve_context(state: AgentState) -> Dict[str, Any]:
+    """Retrieve docs using PKG guidance and return metadata."""
+    query = state["messages"][-1].content
+    doc_ids, meta = _query_pkg(query)
+    if doc_ids:
+        docs = retriever.invoke(query, search_kwargs={"filter": {"id": doc_ids}})
+    else:
+        docs = retriever.invoke(query)
+    return {
+        "context_docs": [d.page_content for d in docs],
+        "graph_metadata": meta,
+    }
+
+
+def plan_step(state: AgentState) -> Dict[str, Any]:
+    """Generate a task list informed by PKG context."""
+    prompt = state["messages"][-1].content
+    _, meta = _query_pkg(prompt)
+    context = ", ".join(m["entity"] for m in meta)
+    llm = ChatOllama()
+    user_prompt = (
+        f"Known entities: {context}\nUser request: {prompt}\nPlan as bullet list."
+    )
+    ai: AIMessage = llm.invoke([HumanMessage(content=user_prompt)])
+    tasks = [t.strip("- ") for t in ai.content.splitlines() if t.strip()]
+    return {"tasks": tasks}

--- a/ingestion/build_pkg.py
+++ b/ingestion/build_pkg.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+"""Build the Personal Knowledge Graph from ingested documents."""
+import os
+from typing import List, Tuple
+
+from langchain_experimental.graph_transformers import LLMGraphTransformer
+from langchain_community.chat_models import ChatOllama
+from neo4j import GraphDatabase
+from langfuse import Langfuse
+from langfuse.langchain import CallbackHandler
+
+from .loaders import load_gmail, load_files
+
+ALLOWED_NODES = ["Person", "Company", "Project", "Document"]
+ALLOWED_RELATIONSHIPS = ["works_on", "communicates_with", "mentions"]
+
+
+def _load_docs(gmail_query: str | None, directory: str | None):
+    docs = []
+    if gmail_query:
+        docs.extend(load_gmail(gmail_query))
+    if directory:
+        docs.extend(load_files(directory))
+    return docs
+
+
+def _store_triples(triples: List[Tuple[str, str, str]]) -> None:
+    driver = GraphDatabase.driver(
+        os.environ.get("NEO4J_URL", "bolt://localhost:7687"),
+        auth=("neo4j", os.environ.get("NEO4J_PASSWORD", "password")),
+    )
+    with driver.session() as session:
+        for s, r, t in triples:
+            session.run(
+                f"MERGE (a {{id:$s}}) MERGE (b {{id:$t}}) MERGE (a)-[:{r}]->(b)",
+                s=s,
+                t=t,
+            )
+
+
+def build_pkg(gmail_query: str | None = None, directory: str | None = None) -> None:
+    """Extract graph triples from documents and store them."""
+    docs = _load_docs(gmail_query, directory)
+    if not docs:
+        print("No documents loaded")
+        return
+
+    llm = ChatOllama()
+    transformer = LLMGraphTransformer(
+        llm=llm,
+        allowed_nodes=ALLOWED_NODES,
+        allowed_relationships=ALLOWED_RELATIONSHIPS,
+    )
+    langfuse = Langfuse()
+    handler = CallbackHandler(langfuse)
+    graph_docs = transformer.convert_to_graph_documents(
+        docs, config={"callbacks": [handler]}
+    )
+
+    triples: List[Tuple[str, str, str]] = []
+    for gdoc in graph_docs:
+        for rel in gdoc.relationships:
+            triples.append((rel.source.id, rel.type, rel.target.id))
+
+    _store_triples(triples)
+    print(f"Stored {len(triples)} triples in Neo4j")
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Build personal knowledge graph")
+    parser.add_argument("--gmail-query", default=None)
+    parser.add_argument("--directory", default=None)
+    args = parser.parse_args()
+
+    build_pkg(args.gmail_query, args.directory)

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,8 @@ langchain-google-community
 ollama
 qdrant-client
 langfuse
+langchain-experimental
+neo4j
 fastapi
 uvicorn
 pytest

--- a/tasks.yml
+++ b/tasks.yml
@@ -9,6 +9,9 @@
   status: done
 - id: extend_pkg
   description: Extend retrieval with a Personal Knowledge Graph powered by LLMGraphTransformer.
+  status: in_progress
+- id: graph_based_planning
+  description: Enhance the planner to reference the PKG when decomposing requests.
   status: todo
 - id: improve_task_management
   description: Improve task management with deterministic rules, LLM prioritization, and human-in-the-loop reflection.

--- a/tests/test_ingestion.py
+++ b/tests/test_ingestion.py
@@ -3,6 +3,8 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")
 
 from unittest.mock import patch, MagicMock
 
+from langchain_experimental.graph_transformers import LLMGraphTransformer
+
 from ingestion import ingest
 from ingestion.ingest import get_text_chunks
 
@@ -26,3 +28,32 @@ def test_ingest_pipeline():
         mock_vs.add_texts.return_value = ["1"]
         ingest("test", "./data")
         assert mock_vs.add_texts.called
+
+
+def test_llm_graph_transformer_schema():
+    from langchain_core.documents import Document
+    from langchain_experimental.graph_transformers.llm import Node, GraphDocument, _Graph
+    from ingestion.build_pkg import ALLOWED_NODES
+    doc = Document(
+        page_content=
+        "John Doe worked on Project Phoenix with ACME Corp and discussed the budget"
+    )
+
+    fake_llm = MagicMock()
+    transformer = LLMGraphTransformer(fake_llm, allowed_nodes=ALLOWED_NODES)
+    fake_graph = _Graph(
+        nodes=[
+            Node(id="John Doe", type="Person"),
+            Node(id="Project Phoenix", type="Project"),
+            Node(id="ACME Corp", type="Company"),
+            Node(id="Budget", type="Finance Topic"),
+        ],
+        relationships=[],
+    )
+    with patch.object(transformer, "chain") as chain:
+        chain.invoke.return_value = {"parsed": fake_graph}
+        gdocs = transformer.convert_to_graph_documents([doc])
+
+    node_types = {n.type for n in gdocs[0].nodes}
+    assert "Finance Topic" not in node_types
+    assert {"Person", "Project", "Company"}.issubset(node_types)

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -1,0 +1,40 @@
+import os, sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from unittest.mock import patch, MagicMock
+from langchain_core.messages import HumanMessage, AIMessage
+
+import agent.nodes as nodes
+
+
+def test_plan_step_uses_pkg():
+    state = {"messages": [HumanMessage(content="plan this")]}
+    fake_llm = MagicMock()
+    fake_llm.invoke.return_value = AIMessage(content="- step1\n- step2")
+    fake_driver = MagicMock()
+    fake_session = fake_driver.session.return_value.__enter__.return_value
+    fake_session.run.return_value = [{"entity": "ProjectX"}]
+    with patch("agent.nodes.ChatOllama", return_value=fake_llm), patch(
+        "agent.nodes.GraphDatabase.driver", return_value=fake_driver
+    ):
+        out = nodes.plan_step(state)
+    assert out["tasks"] == ["step1", "step2"]
+    assert fake_session.run.called
+
+
+def test_retrieve_context_returns_metadata():
+    state = {"messages": [HumanMessage(content="hello")]}
+    fake_driver = MagicMock()
+    fake_session = fake_driver.session.return_value.__enter__.return_value
+    fake_session.run.return_value = [{"id": "1", "entity": "Alice"}]
+    fake_doc = MagicMock()
+    fake_doc.page_content = "hi"
+    fake_retriever = MagicMock()
+    fake_retriever.invoke.return_value = [fake_doc]
+    with patch("agent.nodes.GraphDatabase.driver", return_value=fake_driver), patch(
+        "agent.nodes.retriever", fake_retriever
+    ):
+        out = nodes.retrieve_context(state)
+    assert out["context_docs"] == ["hi"]
+    assert out["graph_metadata"] == [{"doc_id": "1", "entity": "Alice"}]


### PR DESCRIPTION
## Summary
- implement PKG extraction script using `LLMGraphTransformer`
- add graph-aware planner and retriever nodes
- update documentation for new manual validation steps
- mark `extend_pkg` task as in progress and add `graph_based_planning`
- add tests for planner and retrieval nodes
- add neo4j and langchain-experimental to requirements

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6858d18c62d8832a92ba1b088595bc27