### PR TITLE
Add task prioritisation logic

### DIFF
--- a/agent/__init__.py
+++ b/agent/__init__.py
@@ -1,1 +1,3 @@
-from .nodes import plan_step, retrieve_context, AgentState
+from .nodes import plan_step, retrieve_context, prioritise, AgentState
+
+__all__ = ["plan_step", "retrieve_context", "prioritise", "AgentState"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ neo4j
 fastapi
 uvicorn
 pytest
+pyyaml

--- a/rules/priority.yml
+++ b/rules/priority.yml
@@ -1,0 +1,6 @@
+bank_whitelist:
+  - trustedbank.com
+patterns:
+  - regex: "(?i)invoice"
+    priority: med
+default: low


### PR DESCRIPTION
## Summary
- implement deterministic and LLM-based priority logic in `agent.nodes`
- export new `prioritise` node
- add `rules/priority.yml` for simple priority rules
- extend unit tests for prioritisation
- include PyYAML dependency

## Testing
- `pip install -q langchain-experimental langchain-core`
- `pip install -q -r requirements.txt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6858d61d256c832a82b0f88a7ed085c1