### PR TITLE
Add docs via MkDocs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,3 +12,12 @@ ruff:
 	ruff .
 
 .PHONY: dev graph test ruff
+
+
+
+docserve:
+	mkdocs serve
+
+docbuild:
+	mkdocs build --strict
+.PHONY: docserve docbuild

--- a/agent/graph.py
+++ b/agent/graph.py
@@ -64,11 +64,11 @@ def build_graph() -> any:
     graph.add_edge("respond", END)
 
     compiled = graph.compile()
-    os.makedirs("docs", exist_ok=True)
+    os.makedirs("docs/architecture", exist_ok=True)
     try:
-        compiled.get_graph().draw_mermaid_png("docs/langgraph.png")
+        compiled.get_graph().draw_mermaid_png("docs/architecture/langgraph_flow.png")
     except Exception:
-        open("docs/langgraph.png", "wb").close()
+        open("docs/architecture/langgraph_flow.png", "wb").close()
     return compiled
 
 

--- a/docs/architecture/langgraph_flow.md
+++ b/docs/architecture/langgraph_flow.md
@@ -1,0 +1,5 @@
+# LangGraph Flow
+
+This diagram is generated automatically from the agent graph.
+
+![LangGraph Flow](langgraph_flow.png)

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -1,0 +1,3 @@
+# Architecture Overview
+
+This section describes the high level components of the agentic operating system.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,0 +1,3 @@
+# Changelog
+
+--8<-- "../CHANGELOG.md"

--- a/docs/guides/deployment.md
+++ b/docs/guides/deployment.md
@@ -1,0 +1,3 @@
+# Deployment
+
+Guidelines for deploying the agentic operating system.

--- a/docs/guides/hitl_workflow.md
+++ b/docs/guides/hitl_workflow.md
@@ -1,0 +1,3 @@
+# HITL Workflow
+
+Describes human-in-the-loop checkpoints during execution.

--- a/docs/guides/ingestion_pipeline.md
+++ b/docs/guides/ingestion_pipeline.md
@@ -1,0 +1,3 @@
+# Ingestion Pipeline
+
+Details on how documents are ingested and stored in the vector store.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,3 @@
+# Personal Agentic OS
+
+Welcome to the documentation site for the Personal Agentic Operating System.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,0 +1,3 @@
+# Quickstart
+
+Run `make dev` to start the core services and install dependencies. Then run `python -m agent.graph` to generate a diagram of the LangGraph.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,40 @@
+site_name: Personal Agentic OS
+repo_url: https://github.com/you/agent-os
+theme:
+  name: material
+  features:
+    - navigation.tabs
+    - navigation.instant
+    - content.code.copy
+    - content.action.edit
+markdown_extensions:
+  - admonition
+  - pymdownx.highlight
+  - pymdownx.superfences
+  - attr_list
+plugins:
+  - search
+  - mermaid2
+  - git-revision-date-localized
+  - mkdocstrings:
+      handlers:
+        python:
+          options:
+            show_root_toc_entry: false
+            merge_init_into_class: true
+nav:
+  - "\U0001F3E0 Home": index.md
+  - "\U0001F680 Quick-start": quickstart.md
+  - "\U0001F9E9 Architecture":
+      - Overview: architecture/overview.md
+      - LangGraph flow: architecture/langgraph_flow.md
+  - "\U0001F469\u200D\U0001F4BB Developer Guides":
+      - Ingestion Pipeline: guides/ingestion_pipeline.md
+      - HITL Workflow: guides/hitl_workflow.md
+      - Deployment: guides/deployment.md
+  - "\U0001F52C API Reference": api/
+  - "\U0001F5D2 Changelog": changelog.md
+  - "\U0001F4DC Core Specs":
+      - Agents: ../AGENTS.md
+      - Task Contract: ../TASKS.md
+      - Dev Environment: ../DEV_ENV.md


### PR DESCRIPTION
## Summary
- scaffold docs folder with MkDocs-compatible Markdown files
- configure `mkdocs.yml` with Material theme and nav links to core specs
- generate LangGraph diagram under `docs/architecture`
- add `docserve` and `docbuild` targets to Makefile

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6858f24c8ad4832aac7ed1c4d590857d