### PR TITLE
Add script-friendly imports for ingestion utilities

### DIFF
--- a/ingestion/build_pkg.py
+++ b/ingestion/build_pkg.py
@@ -10,13 +10,24 @@ from neo4j import GraphDatabase
 from langfuse import Langfuse
 from langfuse.langchain import CallbackHandler
 
-from .pkg_config import (
-    ALLOWED_NODE_TYPES,
-    ALLOWED_EDGE_TYPES,
-    install_constraints,
-)
+# Support running as a script (`python ingestion/build_pkg.py`) or module
+if __package__:
+    from .pkg_config import (
+        ALLOWED_NODE_TYPES,
+        ALLOWED_EDGE_TYPES,
+        install_constraints,
+    )
+else:  # pragma: no cover - direct script execution
+    from pkg_config import (  # type: ignore
+        ALLOWED_NODE_TYPES,
+        ALLOWED_EDGE_TYPES,
+        install_constraints,
+    )
 
-from .loaders import load_gmail, load_files
+    from loaders import load_gmail, load_files  # type: ignore
+
+if __package__:
+    from .loaders import load_gmail, load_files
 
 
 

--- a/ingestion/ingest.py
+++ b/ingestion/ingest.py
@@ -8,9 +8,13 @@ from langchain_community.embeddings import OllamaEmbeddings
 from langchain_community.vectorstores import Qdrant
 from qdrant_client import QdrantClient
 
-from .embedding_pipeline import split_documents
-
-from .loaders import load_gmail, load_files
+# Support running as a script (`python ingestion/ingest.py`) or module
+if __package__:
+    from .embedding_pipeline import split_documents
+    from .loaders import load_gmail, load_files
+else:  # pragma: no cover - direct script execution
+    from embedding_pipeline import split_documents  # type: ignore
+    from loaders import load_gmail, load_files  # type: ignore
 
 
 CHUNK_SIZE = 1000

--- a/ingestion/loaders.py
+++ b/ingestion/loaders.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from typing import List
 
 from langchain_google_community import GMailLoader
-from langchain_community.document_loaders import DirectoryLoader
+from langchain_community.document_loaders import DirectoryLoader, TextLoader
 from langchain_core.documents import Document
 
 
@@ -26,5 +26,5 @@ def load_gmail(query: str | None = None, *, label: str | None = None, max_result
 
 def load_files(path: str) -> List[Document]:
     """Load documents from a local directory."""
-    loader = DirectoryLoader(path)
+    loader = DirectoryLoader(path, loader_cls=TextLoader)
     return loader.load()


### PR DESCRIPTION
## Summary
- allow `ingestion/build_pkg.py` to run directly as a script
- same treatment for `ingestion/ingest.py`
- update file loader to avoid optional `unstructured` dependency

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6858f839e41c832ab3418ef0aee78814