### PR TITLE
Implement filtered triples in PKG builder

### DIFF
--- a/tests/test_pkg_schema.py
+++ b/tests/test_pkg_schema.py
@@ -1,6 +1,11 @@
 from unittest.mock import Mock, patch
 
-from ingestion.build_pkg import build_pkg
+from langchain_experimental.graph_transformers.llm import (
+    Node,
+    Relationship,
+    GraphDocument,
+)
+from ingestion.build_pkg import build_pkg, _convert_filter
 
 
 def test_hallucinated_node_rejected():
@@ -24,6 +29,37 @@ def test_hallucinated_node_rejected():
         ]
         added = build_pkg("query", None)
     assert added == 0
+
+
+def test_convert_filter_strips_invalid_triples():
+    fake_transformer = Mock()
+    handler = Mock()
+    from langchain_core.documents import Document
+
+    doc = Document(page_content="stuff")
+    valid_a = Node(id="Alice", type="Person")
+    valid_b = Node(id="Acme", type="Company")
+    good_rel = Relationship(source=valid_a, target=valid_b, type="EMPLOYED_AT")
+    bad_node = Node(id="Gandalf", type="Wizard")
+    bad_rel = Relationship(source=bad_node, target=valid_a, type="MENTIONS")
+    gdoc = GraphDocument(
+        nodes=[valid_a, valid_b, bad_node],
+        relationships=[good_rel, bad_rel],
+        source=doc,
+    )
+    fake_transformer.convert_to_graph_documents.return_value = [gdoc]
+
+    triples = _convert_filter(fake_transformer, [doc], handler)
+
+    assert triples == [
+        (
+            "Alice",
+            "Person",
+            "EMPLOYED_AT",
+            "Acme",
+            "Company",
+        )
+    ]
 
 
 


### PR DESCRIPTION
## Summary
- filter `LLMGraphTransformer` results with `_convert_filter`
- call the new helper from `build_pkg`
- test that forbidden triples are dropped

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6858fad0a778832aaa8b93e74f0ea867