### PR TITLE
Implement PKG-aware RAG retrieval

### DIFF
--- a/agent/retrieve_context.py
+++ b/agent/retrieve_context.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+"""Helper functions for PKG-aware retrieval."""
+
+from typing import Tuple, List
+import os
+import logging
+
+from langchain_community.embeddings import OllamaEmbeddings
+from langchain_community.vectorstores import Qdrant
+from qdrant_client import QdrantClient
+from langchain_core.documents import Document
+from neo4j import GraphDatabase
+
+
+# --- PKG Query --------------------------------------------------------------
+
+
+def query_pkg(query: str) -> Tuple[List[str], List[dict]]:
+    """Return related document IDs and metadata from the graph."""
+    driver = GraphDatabase.driver(
+        os.environ.get("NEO4J_URL", "bolt://localhost:7687"),
+        auth=("neo4j", os.environ.get("NEO4J_PASSWORD", "password")),
+    )
+    with driver.session() as session:
+        result = session.run(
+            """
+            MATCH (d:Document)-[r]->(e)
+            WHERE toLower(e.name) CONTAINS toLower($q)
+            RETURN d.id AS id, e.name AS entity, e.email AS email
+            LIMIT 10
+            """,
+            q=query,
+        )
+        data = []
+        for record in result:
+            entity = record.get("entity")
+            doc_id = record.get("id")
+            email = record.get("email")
+            item = {"entity": entity}
+            if doc_id is not None:
+                item["doc_id"] = doc_id
+            if email is not None:
+                item["email"] = email
+            data.append(item)
+    doc_ids = [d["doc_id"] for d in data if "doc_id" in d]
+    return doc_ids, data
+
+
+# --- Vector Retriever -------------------------------------------------------
+
+
+def _build_retriever() -> any:
+    client = QdrantClient(url=os.environ.get("QDRANT_URL", "http://localhost:6333"))
+    vectorstore = Qdrant(
+        client=client,
+        collection_name="ingestion",
+        embeddings=OllamaEmbeddings(),
+    )
+    return vectorstore.as_retriever()
+
+
+retriever = _build_retriever()
+
+
+# --- Qdrant Filtering -------------------------------------------------------
+
+
+def filter_qdrant_by_entities(query: str, entities: List[str]) -> List[Document]:
+    """Return documents matching the query and entity metadata."""
+    if entities:
+        filter_ = {"must": [{"key": "entities", "match": {"any": entities}}]}
+        docs = retriever.invoke(query, search_kwargs={"filter": filter_})
+        if not docs:
+            logging.warning("PKG filter returned 0 docs; falling back to vector search")
+            docs = retriever.invoke(query)
+    else:
+        docs = retriever.invoke(query)
+    return docs

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,8 +4,10 @@ from unittest.mock import MagicMock
 
 @pytest.fixture(autouse=True)
 def _mock_clients(monkeypatch):
+    import importlib
+    rc = importlib.import_module("agent.retrieve_context")
     dummy = MagicMock()
-    monkeypatch.setattr("agent.nodes.GraphDatabase.driver", lambda *a, **k: dummy)
+    monkeypatch.setattr(rc.GraphDatabase, "driver", lambda *a, **k: dummy)
     monkeypatch.setattr("ingestion.build_pkg.GraphDatabase.driver", lambda *a, **k: dummy)
     monkeypatch.setattr("qdrant_client.QdrantClient", lambda *a, **k: dummy)
     yield


### PR DESCRIPTION
## Summary
- add new `agent/retrieve_context.py` with helper functions
- update nodes to use PKG query and entity filtering
- patch tests for new retrieval logic
- add integration tests for entity filtering and fallback path

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6858fdcdbef4832a9e92647576df1434