### PR TITLE
Add Neo4j service to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,10 +9,19 @@ jobs:
       qdrant:
         image: qdrant/qdrant:v1.9.0
         ports: ["6333:6333"]
+      neo4j:
+        image: neo4j:5.20
+        env:
+          NEO4J_AUTH: neo4j/password
+        ports: ["7687:7687"]
     steps:
       - uses: actions/checkout@v4
       - uses: astrojuanlu/setup-uv@v1
       - run: uv pip install -r requirements.txt
       - run: uv pip install pytest pytest-cov ruff
       - run: ruff .
-      - run: pytest -q --cov=agent --cov-fail-under=80
+      - run: |
+          export NEO4J_URI=bolt://localhost:7687
+          export NEO4J_URL=$NEO4J_URI
+          export NEO4J_PASSWORD=password
+          pytest -q --cov=agent --cov-fail-under=80


### PR DESCRIPTION
## Summary
- run Neo4j 5.20 alongside Qdrant in CI
- expose connection details as env vars before pytest

## Testing
- `ruff .`
- `pytest -q --cov=agent --cov-fail-under=80`

------
https://chatgpt.com/codex/tasks/task_e_685900f2668c832aad47c66f391f6719