### PR TITLE
Implement dynamic embedding pipeline

### DIFF
--- a/ingestion/embedding_pipeline.py
+++ b/ingestion/embedding_pipeline.py
@@ -1,18 +1,82 @@
 from __future__ import annotations
 
-"""Dynamic embedding strategies based on document length."""
-from typing import Iterable, List
+"""Dynamic embedding pipeline with multiple split strategies."""
 
+from typing import Iterable, List
+import re
+
+from langchain_core.documents import Document
 from langchain_text_splitters import RecursiveCharacterTextSplitter
 
 
-def split_documents(docs: Iterable, threshold: int = 1000) -> List[str]:
-    """Return list of chunks using adaptive splitting."""
+RECURSIVE_THRESHOLD = 1200
+SENTENCE_THRESHOLD = 200
+
+_SENTENCE_RE = re.compile(r"(?<=[.!?])\s+")
+
+
+def select_strategy(
+    docs: Iterable[Document],
+    *,
+    recursive_threshold: int = RECURSIVE_THRESHOLD,
+    sentence_threshold: int = SENTENCE_THRESHOLD,
+) -> str:
+    """Choose a splitting strategy based on average document length."""
     docs = list(docs)
     if not docs:
-        return []
+        return "none"
     avg_len = sum(len(d.page_content) for d in docs) / len(docs)
-    if avg_len > threshold:
-        splitter = RecursiveCharacterTextSplitter(chunk_size=1000, chunk_overlap=200)
-        return [c.page_content for c in splitter.split_documents(docs)]
-    return [d.page_content for d in docs]
+    if avg_len > recursive_threshold:
+        return "recursive"
+    if avg_len > sentence_threshold:
+        return "sentence"
+    return "none"
+
+
+def _split_sentence(text: str) -> List[str]:
+    return [s.strip() for s in _SENTENCE_RE.split(text) if s.strip()]
+
+
+def split_documents(
+    docs: Iterable[Document],
+    *,
+    chunk_size: int = 1000,
+    chunk_overlap: int = 200,
+    recursive_threshold: int = RECURSIVE_THRESHOLD,
+    sentence_threshold: int = SENTENCE_THRESHOLD,
+) -> List[Document]:
+    """Split documents using an adaptive strategy.
+
+    Returned chunks contain a ``split_strategy`` metadata field.
+    """
+
+    docs = list(docs)
+    strategy = select_strategy(
+        docs,
+        recursive_threshold=recursive_threshold,
+        sentence_threshold=sentence_threshold,
+    )
+
+    chunks: List[Document] = []
+    if strategy == "recursive":
+        splitter = RecursiveCharacterTextSplitter(
+            chunk_size=chunk_size, chunk_overlap=chunk_overlap
+        )
+        chunks = splitter.split_documents(docs)
+    elif strategy == "sentence":
+        for doc in docs:
+            for sent in _split_sentence(doc.page_content):
+                chunks.append(Document(page_content=sent, metadata=dict(doc.metadata)))
+    else:  # "none"
+        chunks = [Document(page_content=d.page_content, metadata=dict(d.metadata)) for d in docs]
+
+    for chunk in chunks:
+        meta = chunk.metadata or {}
+        meta["split_strategy"] = strategy
+        chunk.metadata = meta
+
+    return chunks
+
+
+__all__ = ["split_documents", "select_strategy"]
+

--- a/ingestion/ingest.py
+++ b/ingestion/ingest.py
@@ -21,7 +21,7 @@ CHUNK_SIZE = 1000
 CHUNK_OVERLAP = 200
 
 
-def get_text_chunks(docs: Iterable) -> List[str]:
+def get_text_chunks(docs: Iterable) -> List:
     """Wrapper for the dynamic embedding pipeline."""
     return split_documents(docs)
 
@@ -38,13 +38,16 @@ def ingest(gmail_query: str | None = None, directory: str | None = None) -> None
         print("No documents loaded")
         return
 
-    texts = get_text_chunks(documents)
+    chunks = get_text_chunks(documents)
+
+    texts = [d.page_content for d in chunks]
+    metas = [d.metadata for d in chunks]
 
     embeddings = OllamaEmbeddings()
     client = QdrantClient(url=os.environ.get("QDRANT_URL", "http://localhost:6333"))
     vectorstore = Qdrant(client=client, collection_name="ingestion", embeddings=embeddings)
 
-    ids = vectorstore.add_texts(texts)
+    ids = vectorstore.add_texts(texts, metadatas=metas)
     print(f"Stored {len(ids)} chunks in Qdrant collection 'ingestion'")
 
 

--- a/tests/test_embedding_pipeline.py
+++ b/tests/test_embedding_pipeline.py
@@ -1,19 +1,35 @@
 import os, sys
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
-from ingestion.embedding_pipeline import split_documents
+from ingestion.embedding_pipeline import split_documents, select_strategy
 from langchain_core.documents import Document
 
 
-def test_split_documents_recursion():
-    docs = [Document(page_content="a" * 3000)]
-    chunks = split_documents(docs, threshold=200)
-    assert len(chunks) > 1
-
-
-def test_split_documents_short():
-    docs = [Document(page_content="short text")]
+def test_recursive_strategy():
+    docs = [Document(page_content="a" * 1500)]
+    strategy = select_strategy(docs)
+    assert strategy == "recursive"
     chunks = split_documents(docs)
-    assert chunks == ["short text"]
+    assert len(chunks) > 1
+    assert all(c.metadata["split_strategy"] == "recursive" for c in chunks)
+
+
+def test_none_strategy():
+    docs = [Document(page_content="short text")]
+    strategy = select_strategy(docs)
+    assert strategy == "none"
+    chunks = split_documents(docs)
+    assert len(chunks) == 1
+    assert chunks[0].page_content == "short text"
+    assert chunks[0].metadata["split_strategy"] == "none"
+
+
+def test_sentence_strategy():
+    docs = [Document(page_content="Sentence one. " * 20)]
+    strategy = select_strategy(docs)
+    assert strategy == "sentence"
+    chunks = split_documents(docs)
+    assert len(chunks) > 1
+    assert all(c.metadata["split_strategy"] == "sentence" for c in chunks)
 
 

--- a/tests/test_ingestion.py
+++ b/tests/test_ingestion.py
@@ -14,6 +14,7 @@ def test_get_text_chunks():
     docs = [Document(page_content="a" * 1500)]
     chunks = get_text_chunks(docs)
     assert len(chunks) > 1
+    assert all(c.metadata["split_strategy"] == "recursive" for c in chunks)
 
 
 def test_ingest_pipeline():
@@ -28,6 +29,9 @@ def test_ingest_pipeline():
         mock_vs.add_texts.return_value = ["1"]
         ingest("test", "./data")
         assert mock_vs.add_texts.called
+        _, kwargs = mock_vs.add_texts.call_args
+        assert "metadatas" in kwargs
+        assert kwargs["metadatas"][0]["split_strategy"]
 
 
 def test_llm_graph_transformer_schema():


### PR DESCRIPTION
## Summary
- add adaptive split strategies in `embedding_pipeline`
- include split strategy metadata in ingestion
- update ingestion tests
- update embedding pipeline tests

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68592e229658832a858014d4d2e76afc