### PR TITLE
Add Qdrant migration script for entities index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,4 +5,6 @@
 - Introduced token overflow guard to trim message history.
 - Implemented dynamic embedding pipeline for ingestion.
 - Added basic tests and coverage fixtures.
+- Introduced `scripts/migrate_qdrant_0.4.0.py` to create a payload index on
+  the `entities` metadata field.
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,4 +1,5 @@
 # Release Notes for v0.4.0
 
 This release introduces a seeded Neo4j service and improves reliability with a token overflow guard. Ingestion now adapts chunking strategy based on document size. Run `make dev` and update your `.env` with `NEO4J_PASSWORD` before starting services.
+The `migrate_qdrant_0.4.0.py` script adds an index on the `entities` field to speed up PKG-aware retrieval. Run it once after upgrading.
 

--- a/scripts/migrate_qdrant_0.4.0.py
+++ b/scripts/migrate_qdrant_0.4.0.py
@@ -1,0 +1,32 @@
+"""Create payload index on entities metadata.
+
+Run this once after upgrading to v0.4.0. Safe to run multiple times.
+"""
+from __future__ import annotations
+
+import os
+from qdrant_client import QdrantClient
+from qdrant_client.http.models import PayloadSchemaType
+
+
+COLLECTION = os.environ.get("QDRANT_COLLECTION", "ingestion")
+URL = os.environ.get("QDRANT_URL", "http://localhost:6333")
+
+
+def migrate() -> None:
+    client = QdrantClient(url=URL)
+    info = client.get_collection(COLLECTION)
+    schema = info.payload_schema or {}
+    if "entities" not in schema:
+        client.create_payload_index(
+            collection_name=COLLECTION,
+            field_name="entities",
+            field_type=PayloadSchemaType.KEYWORD,
+        )
+        print("entities index created")
+    else:
+        print("entities index already exists")
+
+
+if __name__ == "__main__":
+    migrate()

--- a/tests/test_qdrant_migration.py
+++ b/tests/test_qdrant_migration.py
@@ -1,0 +1,26 @@
+from unittest.mock import MagicMock
+import importlib.util
+from pathlib import Path
+
+spec = importlib.util.spec_from_file_location(
+    "migrate", Path("scripts/migrate_qdrant_0.4.0.py")
+)
+mig = importlib.util.module_from_spec(spec)
+assert spec.loader
+spec.loader.exec_module(mig)
+
+
+def test_migrate_creates_index(monkeypatch):
+    dummy = MagicMock()
+    dummy.get_collection.return_value = MagicMock(payload_schema={})
+    monkeypatch.setattr(mig, "QdrantClient", lambda url: dummy)
+    mig.migrate()
+    assert dummy.create_payload_index.called
+
+
+def test_migrate_idempotent(monkeypatch):
+    dummy = MagicMock()
+    dummy.get_collection.return_value = MagicMock(payload_schema={"entities": {"type": "keyword"}})
+    monkeypatch.setattr(mig, "QdrantClient", lambda url: dummy)
+    mig.migrate()
+    assert not dummy.create_payload_index.called


### PR DESCRIPTION
## Summary
- add migration script to create `entities` payload index
- document migration in CHANGELOG and release notes
- test migration script idempotence

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68592f6d3730832a89d45e93822db9aa