### PR TITLE
Add coverage tests and enforce threshold

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,10 +6,10 @@ graph:
 	python -c "from agent.graph import build_graph; build_graph()"
 
 test: ruff
-	pytest -q --cov=agent --cov-report=term-missing
+	pytest -q --cov=agent --cov-report=term-missing --cov-fail-under=80
 
 ruff:
-	ruff .
+	ruff check .
 
 .PHONY: dev graph test ruff
 

--- a/tests/test_embedding_pipeline.py
+++ b/tests/test_embedding_pipeline.py
@@ -33,3 +33,7 @@ def test_sentence_strategy():
     assert all(c.metadata["split_strategy"] == "sentence" for c in chunks)
 
 
+def test_select_strategy_empty():
+    assert select_strategy([]) == "none"
+
+

--- a/tests/test_token_counter.py
+++ b/tests/test_token_counter.py
@@ -20,3 +20,10 @@ def test_trim_long_prompt():
     assert total <= 8192
 
 
+def test_count_tokens_fallback(monkeypatch):
+    """Fallback to word split when tiktoken unavailable."""
+    monkeypatch.setattr(tc, "_encoder", None)
+    text = "hello world"
+    assert tc.count_tokens(text) == 2
+
+


### PR DESCRIPTION
## Summary
- add fallback test for token counter
- cover empty doc path for embedding strategy
- update Makefile for ruff 0.4 and enforce 80% coverage

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68593278fdac832a8650226882bd5d2f