### PR TITLE
Improve task prioritization with LLM scoring

### DIFF
--- a/rules/priority.yml
+++ b/rules/priority.yml
@@ -1,6 +1,15 @@
 bank_whitelist:
   - trustedbank.com
+  - securebank.com
 patterns:
-  - regex: "(?i)invoice"
+  - regex: "(?i)fraud|security alert"
+    priority: critical
+  - regex: "(?i)invoice|payment due"
     priority: med
+  - regex: "(?i)meeting|schedule|calendar"
+    priority: high
+llm_thresholds:
+  critical: 0.9
+  high: 0.75
+  med: 0.5
 default: low

--- a/tests/test_prioritise.py
+++ b/tests/test_prioritise.py
@@ -10,7 +10,9 @@ def test_prioritise_rules():
     }
     from unittest.mock import patch
 
-    with patch("agent.nodes.add_task"), patch("agent.nodes.get_default_client"):
+    with patch("agent.nodes.add_task"), patch("agent.nodes.get_default_client"), patch(
+        "agent.nodes._score_with_llm", return_value=0.2
+    ):
         new_state = prioritise(state)
     assert new_state["current_task"]["priority"] == "high"
     assert new_state["current_task"]["status"] == "READY"


### PR DESCRIPTION
## Summary
- expand deterministic priority rules
- map LLM urgency scores to priority using configured thresholds
- choose the higher priority from rules or LLM
- adjust unit tests for new logic

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685942d035d8832a86b8eb822f584528