### PR TITLE
Add meta-agent runner and scheduling docs

### DIFF
--- a/DEV_ENV.md
+++ b/DEV_ENV.md
@@ -83,3 +83,7 @@ Run `make pull-models` before going offline. If using a mirror registry, update 
 
 ## 9. Test Dataset Stubs
 Place small fixture emails and documents under `tests/fixtures/` for unit tests.
+
+## 10. Scheduling the Meta-Agent
+Run `python scripts/run_meta_agent.py` daily to refresh `guidelines.txt` from reflection logs.
+Add a cron entry or systemd timer that invokes the script once per day.

--- a/Makefile
+++ b/Makefile
@@ -11,10 +11,14 @@ test: ruff
 ruff:
 	ruff check .
 
-.PHONY: dev graph test ruff hitl
+
+.PHONY: dev graph test ruff hitl meta-agent
 
 hitl:
 	python src/hitl_cli.py
+
+meta-agent:
+	python scripts/run_meta_agent.py
 
 
 

--- a/README.md
+++ b/README.md
@@ -77,6 +77,17 @@ Site-rendered docs: <https://adrianwedd.github.io/personal-agentic-operating-sys
 | `make graph`| Render Mermaid PNG of current LangGraph |
 | `make docserve`| Hot-reload MkDocs at <http://127.0.0.1:8000> |
 
+## 🔄 Meta-agent Schedule
+
+Run `scripts/run_meta_agent.py` daily so the system can refine
+`guidelines.txt` from reflection logs. Add a cron entry:
+
+```cron
+0 3 * * * /usr/bin/python /path/to/scripts/run_meta_agent.py >> ~/meta.log 2>&1
+```
+
+Systemd users can create a timer that calls the same script once per day.
+
 ---
 
 ## 🏗 Contributing

--- a/scripts/run_meta_agent.py
+++ b/scripts/run_meta_agent.py
@@ -1,0 +1,9 @@
+"""Run the meta-agent to update guidelines."""
+
+from agent.meta_agent import run_meta_agent
+
+
+if __name__ == "__main__":
+    result = run_meta_agent()
+    if result:
+        print(result)


### PR DESCRIPTION
## Summary
- expose `run_meta_agent()` via `scripts/run_meta_agent.py`
- document how to schedule the meta-agent in README and DEV_ENV
- add Makefile target `meta-agent`

## Testing
- `ruff check .`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_685946911128832aaafefb7a7571a0f4