### PR TITLE
Implement task management API

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,13 +12,17 @@ ruff:
 	ruff check .
 
 
-.PHONY: dev graph test ruff hitl meta-agent
+.PHONY: dev graph test ruff hitl meta-agent task-api
 
 hitl:
 	python src/hitl_cli.py
 
 meta-agent:
 	python scripts/run_meta_agent.py
+
+
+task-api:
+	uvicorn src.task_api:app --reload --port 8001
 
 
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ git clone https://github.com/adrianwedd/personal-agentic-operating-system.git
 cd personal-agentic-operating-system
 ./bootstrap.sh                  # 🚀 zero-click setup wizard
 python src/minimal_agent.py "Summarise my inbox"
+make task-api                   # optional REST interface
 ```
 
 > **Tip:** first launch downloads base Ollama model (~3 GB). Subsequent runs are instant.
@@ -76,6 +77,7 @@ Site-rendered docs: <https://adrianwedd.github.io/personal-agentic-operating-sys
 | `make test`| Ruff lint + pytest + coverage gate (80 %) |
 | `make graph`| Render Mermaid PNG of current LangGraph |
 | `make docserve`| Hot-reload MkDocs at <http://127.0.0.1:8000> |
+| `make task-api`| Launch FastAPI task API |
 
 ## 🔄 Meta-agent Schedule
 

--- a/agent/tasks_db.py
+++ b/agent/tasks_db.py
@@ -72,3 +72,19 @@ def update_task(task: dict):
     client = QdrantClient(url="http://localhost:6333")
     vs = Qdrant(client=client, collection_name=COLLECTION, embeddings=OllamaEmbeddings())
     vs.add_texts([task["objective"]], ids=[task["task_id"]])
+
+
+def get_task(task_id: str) -> dict | None:
+    conn = sqlite3.connect(DB_PATH)
+    row = conn.execute("SELECT data FROM tasks WHERE task_id=?", (task_id,)).fetchone()
+    conn.close()
+    if row:
+        return json.loads(row[0])
+    return None
+
+
+def list_tasks() -> list[dict]:
+    conn = sqlite3.connect(DB_PATH)
+    rows = conn.execute("SELECT data FROM tasks").fetchall()
+    conn.close()
+    return [json.loads(r[0]) for r in rows]

--- a/src/task_api.py
+++ b/src/task_api.py
@@ -1,0 +1,29 @@
+from fastapi import FastAPI, HTTPException
+from agent import tasks_db
+
+app = FastAPI()
+
+
+@app.get("/tasks")
+def list_tasks():
+    return tasks_db.list_tasks()
+
+
+@app.post("/tasks/{task_id}/approve")
+def approve_task(task_id: str):
+    task = tasks_db.get_task(task_id)
+    if not task:
+        raise HTTPException(status_code=404, detail="Task not found")
+    task["status"] = "IN_PROGRESS"
+    tasks_db.update_task(task)
+    return {"status": "ok"}
+
+
+@app.post("/tasks/{task_id}/cancel")
+def cancel_task(task_id: str):
+    task = tasks_db.get_task(task_id)
+    if not task:
+        raise HTTPException(status_code=404, detail="Task not found")
+    task["status"] = "CANCELLED"
+    tasks_db.update_task(task)
+    return {"status": "ok"}

--- a/tests/test_task_api.py
+++ b/tests/test_task_api.py
@@ -1,0 +1,52 @@
+import os, sys, importlib
+import sqlite3
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from unittest.mock import MagicMock
+
+from fastapi.testclient import TestClient
+
+from agent import tasks_db
+
+# import the module after path tweaks
+api = importlib.import_module("src.task_api")
+
+
+def setup_temp_db(tmp_path, monkeypatch):
+    db_path = tmp_path / "tasks.db"
+    monkeypatch.setattr(tasks_db, "DB_PATH", str(db_path))
+    monkeypatch.setattr(tasks_db, "COLLECTION", "test")
+    monkeypatch.setattr(tasks_db, "Qdrant", lambda client, collection_name, embeddings: MagicMock())
+    monkeypatch.setattr(tasks_db, "QdrantClient", lambda url: MagicMock())
+    def init_custom():
+        conn = sqlite3.connect(db_path)
+        conn.execute("CREATE TABLE tasks (task_id TEXT PRIMARY KEY, data TEXT, updated_at TEXT)")
+        conn.commit()
+        conn.close()
+
+    monkeypatch.setattr(tasks_db, "init_db", init_custom)
+    tasks_db.init_db()
+    return db_path
+
+
+def test_list_tasks(tmp_path, monkeypatch):
+    setup_temp_db(tmp_path, monkeypatch)
+    tasks_db.add_task({"task_id": "1", "objective": "demo", "status": "NEW"})
+    client = TestClient(api.app)
+    resp = client.get("/tasks")
+    assert resp.status_code == 200
+    assert resp.json()[0]["task_id"] == "1"
+
+
+def test_approve_and_cancel(tmp_path, monkeypatch):
+    setup_temp_db(tmp_path, monkeypatch)
+    task = {"task_id": "2", "objective": "demo", "status": "WAITING_HITL"}
+    tasks_db.add_task(task)
+    client = TestClient(api.app)
+    resp = client.post("/tasks/2/approve")
+    assert resp.status_code == 200
+    updated = tasks_db.get_task("2")
+    assert updated["status"] == "IN_PROGRESS"
+    resp = client.post("/tasks/2/cancel")
+    assert resp.status_code == 200
+    updated = tasks_db.get_task("2")
+    assert updated["status"] == "CANCELLED"


### PR DESCRIPTION
## Summary
- add FastAPI application for task management endpoints
- expand `agent.tasks_db` with getters
- document new `make task-api` target and update quick-start
- include unit tests for the API

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68594ac51258832a921d5be52e593d49