### PR TITLE
Add tests for HITL, meta-agent integration and scoring helpers

### DIFF
--- a/tests/test_hitl_flow.py
+++ b/tests/test_hitl_flow.py
@@ -1,0 +1,31 @@
+import os, sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "src")))
+import hitl_cli
+
+def test_hitl_write_and_process(tmp_path, monkeypatch):
+    queue_dir = tmp_path / "queue"
+    refl_dir = tmp_path / "logs"
+    monkeypatch.setattr("hitl_cli.QUEUE_DIR", str(queue_dir))
+    monkeypatch.setattr("hitl_cli.REFLECT_DIR", str(refl_dir))
+
+    class DummyStore:
+        def __init__(self):
+            self.texts = []
+
+        def add_texts(self, texts, ids=None):
+            self.texts.extend(texts)
+
+    dummy = DummyStore()
+    monkeypatch.setattr(
+        "hitl_cli.Qdrant", lambda client, collection_name, embeddings: dummy
+    )
+    monkeypatch.setattr("hitl_cli.QdrantClient", lambda url: None)
+    monkeypatch.setattr("hitl_cli.OllamaEmbeddings", lambda: None)
+
+    hitl_cli.write_hitl({"task_id": "1"})
+    assert (queue_dir / "1.json").exists()
+
+    hitl_cli.process_queue(action="approved")
+    assert dummy.texts
+    assert list(refl_dir.glob("*.jsonl"))
+

--- a/tests/test_meta_agent_integration.py
+++ b/tests/test_meta_agent_integration.py
@@ -1,0 +1,26 @@
+from langchain_core.messages import AIMessage
+from langchain_core.documents import Document
+from unittest.mock import MagicMock
+import agent.meta_agent as meta
+
+
+def test_run_meta_agent_updates_guidelines(tmp_path, monkeypatch):
+    monkeypatch.setattr(meta, "GUIDELINES_FILE", str(tmp_path / "guide.txt"))
+
+    class DummyStore:
+        def similarity_search(self, query, k=20):
+            return [Document(page_content="reflect1")]
+
+    monkeypatch.setattr(meta, "Qdrant", lambda client, collection_name, embeddings: DummyStore())
+    monkeypatch.setattr(meta, "QdrantClient", lambda url: None)
+    monkeypatch.setattr(meta, "OllamaEmbeddings", lambda: None)
+
+    fake_llm = MagicMock()
+    fake_llm.chat.return_value = AIMessage(content="New guideline")
+    monkeypatch.setattr(meta, "get_default_client", lambda: fake_llm)
+
+    result = meta.run_meta_agent()
+    assert result == "New guideline"
+    with open(tmp_path / "guide.txt") as fh:
+        assert "New guideline" in fh.read()
+


### PR DESCRIPTION
## Summary
- remove HITL reflection check from node tests
- add unit tests for `_score_with_llm` and `_priority_from_score`
- create `test_hitl_flow.py` covering HITL queue and reflection log
- test meta-agent integration via `run_meta_agent`

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6859512e8604832a98afbfb729113a28