### PR TITLE
Add ClickHouse dev tuning config

### DIFF
--- a/docker/clickhouse/config.xml
+++ b/docker/clickhouse/config.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0"?>
+<yandex>
+    <logger>
+        <level>information</level>
+        <console>true</console>
+        <log>/var/log/clickhouse-server/clickhouse.log</log>
+        <errorlog>/var/log/clickhouse-server/clickhouse.err.log</errorlog>
+    </logger>
+    <background_pool_size>4</background_pool_size>
+    <background_move_pool_size>1</background_move_pool_size>
+    <background_fetches_pool_size>2</background_fetches_pool_size>
+    <merge_tree>
+        <max_bytes_to_merge_at_min_space_in_pool>1073741824</max_bytes_to_merge_at_min_space_in_pool>
+        <max_bytes_to_merge_at_max_space_in_pool>2147483648</max_bytes_to_merge_at_max_space_in_pool>
+        <parts_to_delay_insert>300</parts_to_delay_insert>
+        <parts_to_throw_insert>600</parts_to_throw_insert>
+    </merge_tree>
+    <system_logs>
+        <metric_log>
+            <engine>
+                <ttl>event_time + INTERVAL 3 DAY</ttl>
+            </engine>
+        </metric_log>
+        <trace_log>
+            <engine>
+                <ttl>event_time + INTERVAL 3 DAY</ttl>
+            </engine>
+        </trace_log>
+        <asynchronous_metric_log>
+            <engine>
+                <ttl>event_time + INTERVAL 3 DAY</ttl>
+            </engine>
+        </asynchronous_metric_log>
+    </system_logs>
+</yandex>

--- a/docs/guides/clickhouse_tuning.md
+++ b/docs/guides/clickhouse_tuning.md
@@ -1,0 +1,20 @@
+# ClickHouse Tuning for Development
+
+ClickHouse's system tables generate frequent background merges which can flood the console when the server runs with a high log level. To keep logs readable on a dev machine, use the custom config below and periodically prune the system tables.
+
+## Configuration
+
+1. Copy `docker/clickhouse/config.xml` into your container at `/etc/clickhouse-server/config.d/dev.xml`.
+2. Restart the `clickhouse` service to apply the settings.
+
+The config lowers the log level to `information`, limits background threads and keeps system logs for only three days.
+
+## Pruning helper
+
+Run `scripts/prune-system-logs.sh` occasionally (or via cron) to enforce the 3‑day TTL and reclaim disk space:
+
+```bash
+$ docker exec clickhouse-server /scripts/prune-system-logs.sh
+```
+
+This script modifies the TTL on ClickHouse's system logs and performs a `FINAL` optimize.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -29,5 +29,6 @@ nav:
   - Guides:
       - Ingestion Pipeline: guides/ingestion_pipeline.md
       - HITL Workflow: guides/hitl_workflow.md
+      - ClickHouse Tuning: guides/clickhouse_tuning.md
   - API Reference: api/index.md
   - Changelog: changelog.md

--- a/scripts/prune-system-logs.sh
+++ b/scripts/prune-system-logs.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Minimal helper: set TTLs and optimize system logs
+CH="clickhouse-client --host localhost --user default --password ''"
+
+tables=(
+  "system.metric_log"
+  "system.trace_log"
+  "system.asynchronous_metric_log"
+)
+
+for t in "${tables[@]}"; do
+  echo "→ Enforcing 3-day TTL on $t"
+  $CH -q "ALTER TABLE $t MODIFY TTL event_time + INTERVAL 3 DAY"
+done
+
+echo "→ Running FINAL OPTIMIZE to reclaim disk now"
+for t in "${tables[@]}"; do
+  $CH -q "OPTIMIZE TABLE $t FINAL"
+done


### PR DESCRIPTION
## Summary
- add example ClickHouse configuration with lower log level and TTLs
- add pruning helper script for system log tables
- document ClickHouse tuning steps and reference in MkDocs nav

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68595edb2550832ab963113a72d8fda5