### PR TITLE
Add service URL cheat sheet

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -102,6 +102,9 @@ bold ""
 green "🎉  All services requested. Quick status:"
 docker compose ps --format "table {{.Name}}\t{{.State}}\t{{.Ports}}"
 
+# Friendly URL cheat-sheet
+scripts/print_service_urls.sh "$@"
+
 bold ""
 bold "👟  Next steps"
 cat <<EOT

--- a/scripts/print_service_urls.sh
+++ b/scripts/print_service_urls.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Friendly URL cheat-sheet
+
+echo ""
+echo "🌐  Open your browser:"
+printf "%-16s →  %s\n"  "Langfuse UI"          "http://localhost:${LANGFUSE_PORT:-57660}"
+printf "%-16s →  %s/play\n"  "ClickHouse UI"   "http://localhost:${CLICKHOUSE_HTTP_PORT:-57659}"
+printf "%-16s →  %s\n"  "Neo4j Browser"       "http://localhost:${NEO4J_HTTP_PORT:-7474}"
+printf "%-16s →  %s\n"  "Ollama REST"         "http://localhost:${OLLAMA_PORT:-11434}"
+printf "%-16s →  %s\n"  "Qdrant REST"         "http://localhost:${QDRANT_PORT:-52873}"
+echo ""
+echo "Tip: add '--ui' to auto-open Langfuse in your default browser."
+
+if [[ "${1:-}" == "--ui" ]]; then
+    if command -v xdg-open >/dev/null 2>&1; then
+        xdg-open "http://localhost:${LANGFUSE_PORT:-57660}" >/dev/null 2>&1 &
+    elif command -v open >/dev/null 2>&1; then
+        open "http://localhost:${LANGFUSE_PORT:-57660}" >/dev/null 2>&1 &
+    fi
+fi


### PR DESCRIPTION
## Summary
- add a helper script to print service URLs
- call the helper from `bootstrap.sh` after showing `docker compose` status

## Testing
- `make test` *(fails: Docker not available)*

------
https://chatgpt.com/codex/tasks/task_e_685964f5e344832aaef38808a702a9e0