### PR TITLE
Fix port detection in print_service_urls

### DIFF
--- a/scripts/print_service_urls.sh
+++ b/scripts/print_service_urls.sh
@@ -1,22 +1,28 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Friendly URL cheat-sheet
+source "$(dirname "$0")/util_docker_port.sh"
+
+langfuse_port=$(get_host_port langfuse 3000/tcp    "${LANGFUSE_PORT:-57660}")
+ch_http_port=$(get_host_port clickhouse 8123/tcp   "${CLICKHOUSE_HTTP_PORT:-57659}")
+neo4j_http=$(get_host_port neo4j 7474/tcp          "${NEO4J_HTTP_PORT:-7474}")
+ollama_port=$(get_host_port ollama 11434/tcp       "${OLLAMA_PORT:-11434}")
+qdrant_port=$(get_host_port qdrant 6333/tcp        "${QDRANT_PORT:-52873}")
 
 echo ""
 echo "🌐  Open your browser:"
-printf "%-16s →  %s\n"  "Langfuse UI"          "http://localhost:${LANGFUSE_PORT:-57660}"
-printf "%-16s →  %s/play\n"  "ClickHouse UI"   "http://localhost:${CLICKHOUSE_HTTP_PORT:-57659}"
-printf "%-16s →  %s\n"  "Neo4j Browser"       "http://localhost:${NEO4J_HTTP_PORT:-7474}"
-printf "%-16s →  %s\n"  "Ollama REST"         "http://localhost:${OLLAMA_PORT:-11434}"
-printf "%-16s →  %s\n"  "Qdrant REST"         "http://localhost:${QDRANT_PORT:-52873}"
+printf "%-16s →  http://localhost:%s\n" "Langfuse UI"     "$langfuse_port"
+printf "%-16s →  http://localhost:%s/play\n" "ClickHouse UI" "$ch_http_port"
+printf "%-16s →  http://localhost:%s\n" "Neo4j Browser"  "$neo4j_http"
+printf "%-16s →  http://localhost:%s\n" "Ollama REST"    "$ollama_port"
+printf "%-16s →  http://localhost:%s\n" "Qdrant REST"    "$qdrant_port"
 echo ""
 echo "Tip: add '--ui' to auto-open Langfuse in your default browser."
 
 if [[ "${1:-}" == "--ui" ]]; then
     if command -v xdg-open >/dev/null 2>&1; then
-        xdg-open "http://localhost:${LANGFUSE_PORT:-57660}" >/dev/null 2>&1 &
+        xdg-open "http://localhost:${langfuse_port}" >/dev/null 2>&1 &
     elif command -v open >/dev/null 2>&1; then
-        open "http://localhost:${LANGFUSE_PORT:-57660}" >/dev/null 2>&1 &
+        open "http://localhost:${langfuse_port}" >/dev/null 2>&1 &
     fi
 fi

--- a/scripts/util_docker_port.sh
+++ b/scripts/util_docker_port.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Helper: resolve host port for a compose service
+# $1 - service name in docker-compose
+# $2 - container port spec, e.g. 3000/tcp
+# $3 - default port if lookup fails
+get_host_port() {
+    docker compose port "$1" "$2" 2>/dev/null | \
+        awk -F':' 'NF==2 {print $2; exit}' |
+        { read -r p && [[ -n "$p" ]] && echo "$p" || echo "$3"; }
+}


### PR DESCRIPTION
## Summary
- add helper `scripts/util_docker_port.sh` to fetch host ports from Docker
- use the helper in `print_service_urls.sh` so URLs match actual mappings

## Testing
- `make ruff`
- `make test` *(fails: Docker not available in test environment)*

------
https://chatgpt.com/codex/tasks/task_e_685969443388832a87aaaf44fe4000e3