### PR TITLE
Add trace-agent and graph inspector UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ cd personal-agentic-operating-system
 ./bootstrap.sh                  # 🚀 zero-click setup wizard
 python src/minimal_agent.py "Summarise my inbox"
 make task-api                   # optional REST interface
+cd apps/graph-inspector && yarn dev  # live LangGraph viewer
 ```
 
 > **Tip:** first launch downloads base Ollama model (~3 GB). Subsequent runs are instant.
@@ -78,6 +79,7 @@ Site-rendered docs: <https://adrianwedd.github.io/personal-agentic-operating-sys
 | `make graph`| Render Mermaid PNG of current LangGraph |
 | `make docserve`| Hot-reload MkDocs at <http://127.0.0.1:8000> |
 | `make task-api`| Launch FastAPI task API |
+| `yarn dev` (apps/graph-inspector)| Live graph inspector UI |
 
 ## 🔄 Meta-agent Schedule
 

--- a/agent/graph.py
+++ b/agent/graph.py
@@ -18,6 +18,7 @@ from .nodes import (
     generate_response,
     hitl_pause,
 )
+from trace_agent.decorators import traced
 
 
 HITL_DIR = "data/hitl_queue"
@@ -37,13 +38,13 @@ def human_approval(state: AgentState) -> dict:
 
 def build_graph() -> any:
     graph = StateGraph(AgentState)
-    graph.add_node("plan", plan_step)
-    graph.add_node("prioritise", prioritise)
-    graph.add_node("retrieve", retrieve_context)
-    graph.add_node("execute", execute_tool)
-    graph.add_node("hitl", human_approval)
-    graph.add_node("pause", hitl_pause)
-    graph.add_node("respond", generate_response)
+    graph.add_node("plan", traced("plan")(plan_step))
+    graph.add_node("prioritise", traced("prioritise")(prioritise))
+    graph.add_node("retrieve", traced("retrieve")(retrieve_context))
+    graph.add_node("execute", traced("execute")(execute_tool))
+    graph.add_node("hitl", traced("hitl")(human_approval))
+    graph.add_node("pause", traced("pause")(hitl_pause))
+    graph.add_node("respond", traced("respond")(generate_response))
 
     graph.set_entry_point("plan")
     graph.add_edge("plan", "prioritise")

--- a/apps/graph-inspector/Dockerfile
+++ b/apps/graph-inspector/Dockerfile
@@ -1,0 +1,11 @@
+FROM node:20-alpine AS build
+WORKDIR /app
+COPY package.json package-lock.json* ./
+RUN npm install
+COPY . .
+RUN npm run build
+
+FROM nginx:alpine
+COPY --from=build /app/dist /usr/share/nginx/html
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]

--- a/apps/graph-inspector/PLAN.md
+++ b/apps/graph-inspector/PLAN.md
@@ -89,6 +89,10 @@ Phase | Task | Output
 cd trace-agent && uvicorn main:app --reload
 cd apps/graph-inspector && yarn dev
 ```
+To run inside Docker:
+```bash
+docker compose up trace-agent graph-inspector
+```
 
 ## CODEX tasks
 

--- a/apps/graph-inspector/index.html
+++ b/apps/graph-inspector/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Graph Inspector</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/apps/graph-inspector/package.json
+++ b/apps/graph-inspector/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "graph-inspector",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "reactflow": "^11.10.4"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.0",
+    "@types/react-dom": "^18.2.0",
+    "@vitejs/plugin-react": "^4.1.0",
+    "typescript": "^5.4.2",
+    "vite": "^5.0.0"
+  }
+}

--- a/apps/graph-inspector/src/App.tsx
+++ b/apps/graph-inspector/src/App.tsx
@@ -1,0 +1,43 @@
+import React, { useEffect, useState } from 'react';
+import ReactFlow, { Node, Edge } from 'reactflow';
+import 'reactflow/dist/style.css';
+
+const initialNodes: Node[] = [
+  { id: 'plan', position: { x: 0, y: 0 }, data: { label: 'plan' } },
+  { id: 'prioritise', position: { x: 150, y: 0 }, data: { label: 'prioritise' } },
+  { id: 'retrieve', position: { x: 300, y: 0 }, data: { label: 'retrieve' } },
+  { id: 'execute', position: { x: 450, y: 0 }, data: { label: 'execute' } },
+  { id: 'respond', position: { x: 600, y: 0 }, data: { label: 'respond' } }
+];
+
+const edges: Edge[] = [
+  { id: 'e1', source: 'plan', target: 'prioritise' },
+  { id: 'e2', source: 'prioritise', target: 'retrieve' },
+  { id: 'e3', source: 'retrieve', target: 'execute' },
+  { id: 'e4', source: 'execute', target: 'respond' }
+];
+
+export default function App() {
+  const [nodes, setNodes] = useState<Node[]>(initialNodes);
+
+  useEffect(() => {
+    const es = new EventSource('/graph-events');
+    es.onmessage = (evt) => {
+      const data = JSON.parse(evt.data);
+      setNodes((nds) =>
+        nds.map((n) =>
+          n.id === data.node
+            ? { ...n, style: { background: data.event === 'start' ? '#fde047' : '#86efac' } }
+            : n
+        )
+      );
+    };
+    return () => es.close();
+  }, []);
+
+  return (
+    <div style={{ width: '100%', height: '100vh' }}>
+      <ReactFlow nodes={nodes} edges={edges} fitView />
+    </div>
+  );
+}

--- a/apps/graph-inspector/src/main.tsx
+++ b/apps/graph-inspector/src/main.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/apps/graph-inspector/tsconfig.json
+++ b/apps/graph-inspector/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "jsx": "react-jsx",
+    "moduleResolution": "node",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  }
+}

--- a/apps/graph-inspector/vite.config.ts
+++ b/apps/graph-inspector/vite.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 5173
+  }
+});

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -61,6 +61,24 @@ services:
       - ./data/neo4j:/data
       - ./constraints.cypher:/docker-entrypoint-initdb.d/constraints.cypher:ro
     networks: ["agentnet"]
+  trace-agent:
+    build:
+      context: .
+      dockerfile: trace_agent/Dockerfile
+    container_name: trace-agent
+    ports:
+      - "8000:8000"
+    networks: ["agentnet"]
+  graph-inspector:
+    build:
+      context: apps/graph-inspector
+      dockerfile: Dockerfile
+    container_name: graph-inspector
+    depends_on:
+      - trace-agent
+    ports:
+      - "5173:80"
+    networks: ["agentnet"]
 
 networks:
   agentnet:

--- a/scripts/print_service_urls.sh
+++ b/scripts/print_service_urls.sh
@@ -10,6 +10,8 @@ printf "%-16s →  %s/play\n"  "ClickHouse UI"   "http://localhost:${CLICKHOUSE_
 printf "%-16s →  %s\n"  "Neo4j Browser"       "http://localhost:${NEO4J_HTTP_PORT:-7474}"
 printf "%-16s →  %s\n"  "Ollama REST"         "http://localhost:${OLLAMA_PORT:-11434}"
 printf "%-16s →  %s\n"  "Qdrant REST"         "http://localhost:${QDRANT_PORT:-52873}"
+printf "%-16s →  %s\n"  "Trace API"          "http://localhost:8000"
+printf "%-16s →  %s\n"  "Graph UI"           "http://localhost:5173"
 echo ""
 echo "Tip: add '--ui' to auto-open Langfuse in your default browser."
 

--- a/trace_agent/Dockerfile
+++ b/trace_agent/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY requirements.txt ./
+RUN pip install --no-cache-dir fastapi uvicorn
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+CMD ["uvicorn", "trace_agent.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/trace_agent/decorators.py
+++ b/trace_agent/decorators.py
@@ -1,0 +1,18 @@
+from functools import wraps
+from .event_broker import broker
+
+
+def traced(node_name: str):
+    """Emit start and end events around a node call."""
+
+    def decorator(fn):
+        @wraps(fn)
+        def wrapper(*args, **kwargs):
+            broker.emit({"node": node_name, "event": "start"})
+            result = fn(*args, **kwargs)
+            broker.emit({"node": node_name, "event": "end"})
+            return result
+
+        return wrapper
+
+    return decorator

--- a/trace_agent/event_broker.py
+++ b/trace_agent/event_broker.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+import asyncio
+from typing import Any, Set
+
+
+class EventBroker:
+    def __init__(self) -> None:
+        self.listeners: Set[asyncio.Queue] = set()
+
+    def register(self) -> asyncio.Queue:
+        q: asyncio.Queue = asyncio.Queue()
+        self.listeners.add(q)
+        return q
+
+    def unregister(self, q: asyncio.Queue) -> None:
+        self.listeners.discard(q)
+
+    def emit(self, event: dict) -> None:
+        for listener in list(self.listeners):
+            listener.put_nowait(event)
+
+
+broker = EventBroker()

--- a/trace_agent/main.py
+++ b/trace_agent/main.py
@@ -1,0 +1,21 @@
+from fastapi import FastAPI
+from fastapi.responses import StreamingResponse
+import json
+from .event_broker import broker
+
+app = FastAPI()
+
+
+@app.get("/graph-events")
+async def graph_events() -> StreamingResponse:
+    queue = broker.register()
+
+    async def event_stream():
+        try:
+            while True:
+                event = await queue.get()
+                yield f"data: {json.dumps(event)}\n\n"
+        finally:
+            broker.unregister(queue)
+
+    return StreamingResponse(event_stream(), media_type="text/event-stream")


### PR DESCRIPTION
## Summary
- stream LangGraph node events via new trace-agent FastAPI service
- scaffold React Flow graph-inspector app
- show running graph visually and update colors as nodes start/finish
- wire services into docker-compose and bootstrap helpers
- document workflow for the inspector in README and PLAN

## Testing
- `make test` *(fails: Docker not available for ClickHouse tests)*

------
https://chatgpt.com/codex/tasks/task_e_68596975e8f0832a91ffcf3e13ff6c98