### PR TITLE
Add toolkit helpers module

### DIFF
--- a/agent/nodes.py
+++ b/agent/nodes.py
@@ -15,10 +15,11 @@ from datetime import datetime
 from .state import AgentState
 from .tasks_db import add_task
 from langgraph.prebuilt import ToolNode
+from . import tools as agent_tools
 from utils.token_counter import trim_messages, count_message_tokens
 from .retrieve_context import query_pkg, filter_qdrant_by_entities
 
-tool_node = ToolNode([])
+tool_node = ToolNode(agent_tools.build_action_tools())
 
 
 def remaining_steps(task: dict) -> bool:

--- a/agent/tools.py
+++ b/agent/tools.py
@@ -1,0 +1,59 @@
+"""Utility functions for Gmail and Calendar tools."""
+from __future__ import annotations
+
+from typing import List, Iterable
+
+from langchain_core.tools import BaseTool
+from langchain_google_community.gmail.toolkit import GmailToolkit, SCOPES as GMAIL_SCOPES
+from langchain_google_community.gmail.utils import build_resource_service as build_gmail_service
+from langchain_google_community.calendar.toolkit import CalendarToolkit, SCOPES as CAL_SCOPES
+from langchain_google_community.calendar.utils import build_resource_service as build_calendar_service
+
+
+def _sanitize_tool(tool: BaseTool) -> BaseTool:
+    """Hide API credentials when serializing tool objects."""
+    original_dump = tool.model_dump
+
+    def safe_dump(*args, **kwargs):
+        exclude = set(kwargs.pop("exclude", set()))
+        exclude.add("api_resource")
+        return original_dump(*args, exclude=exclude, **kwargs)
+
+    tool.model_dump = safe_dump  # type: ignore[assignment]
+    return tool
+
+
+def build_gmail_toolkit(scopes: Iterable[str] | None = None) -> GmailToolkit:
+    """Return a GmailToolkit with read/write scopes."""
+    return GmailToolkit(api_resource=build_gmail_service(scopes=list(scopes or GMAIL_SCOPES)))
+
+
+def build_calendar_toolkit(scopes: Iterable[str] | None = None) -> CalendarToolkit:
+    """Return a Google CalendarToolkit with read/write scopes."""
+    return CalendarToolkit(api_resource=build_calendar_service(scopes=list(scopes or CAL_SCOPES)))
+
+
+def build_gmail_tools() -> List[BaseTool]:
+    """Return sanitized Gmail tools."""
+    try:
+        toolkit = build_gmail_toolkit()
+        tools = toolkit.get_tools()
+    except Exception:
+        tools = []
+    return [_sanitize_tool(t) for t in tools]
+
+
+def build_calendar_tools() -> List[BaseTool]:
+    """Return sanitized Google Calendar tools."""
+    try:
+        toolkit = build_calendar_toolkit()
+        tools = toolkit.get_tools()
+    except Exception:
+        tools = []
+    return [_sanitize_tool(t) for t in tools]
+
+
+def build_action_tools() -> List[BaseTool]:
+    """Return all available Gmail and Calendar tools."""
+    return build_gmail_tools() + build_calendar_tools()
+

--- a/src/tool_agent.py
+++ b/src/tool_agent.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import List, Dict, TypedDict
 
 from agent.llm_providers import get_default_client
-from langchain_google_community import GmailToolkit, CalendarToolkit
+from agent import tools as agent_tools
 from langfuse import Langfuse
 from langfuse.langchain import CallbackHandler
 from langchain_core.messages import HumanMessage, AIMessage, BaseMessage
@@ -20,10 +20,8 @@ class AgentState(TypedDict):
 
 
 def build_tools() -> List:
-    """Instantiate Gmail and Calendar tools."""
-    gmail_tools = GmailToolkit().get_tools()
-    cal_tools = CalendarToolkit().get_tools()
-    return list(gmail_tools) + list(cal_tools)
+    """Return sanitized Gmail and Calendar tools."""
+    return agent_tools.build_action_tools()
 
 
 def build_agent() -> any:

--- a/tests/test_tool_agent.py
+++ b/tests/test_tool_agent.py
@@ -11,12 +11,7 @@ main = tool_agent.main
 
 
 def test_build_tools():
-    fake_gmail = MagicMock()
-    fake_gmail.get_tools.return_value = ["g"]
-    fake_cal = MagicMock()
-    fake_cal.get_tools.return_value = ["c"]
-    with patch("tool_agent.GmailToolkit", return_value=fake_gmail), \
-         patch("tool_agent.CalendarToolkit", return_value=fake_cal):
+    with patch("tool_agent.agent_tools.build_action_tools", return_value=["g", "c"]):
         tools = build_tools()
     assert tools == ["g", "c"]
 

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1,0 +1,40 @@
+import os, sys, importlib, json
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+agent_tools = importlib.import_module("agent.tools")
+
+
+def test_build_action_tools_list():
+    class T:
+        def model_dump(self, *a, **k):
+            return {}
+    fake_gmail = MagicMock()
+    fake_gmail.get_tools.return_value = [T()]
+    fake_cal = MagicMock()
+    fake_cal.get_tools.return_value = [T()]
+    with patch("agent.tools.build_gmail_service", return_value=MagicMock()), \
+         patch("agent.tools.build_calendar_service", return_value=MagicMock()), \
+         patch("agent.tools.GmailToolkit", return_value=fake_gmail), \
+         patch("agent.tools.CalendarToolkit", return_value=fake_cal):
+        tools = agent_tools.build_action_tools()
+    assert len(tools) == 2
+
+
+def test_tools_sanitizes_tokens():
+    class FakeTool:
+        def __init__(self):
+            self.api_resource = {"credentials": {"token": "secret"}}
+        def model_dump(self, *a, exclude=None, **k):
+            if exclude and "api_resource" in exclude:
+                return {}
+            return {"api_resource": self.api_resource}
+    fake_gmail = MagicMock()
+    fake_gmail.get_tools.return_value = [FakeTool()]
+    with patch("agent.tools.build_gmail_service", return_value=MagicMock()), \
+         patch("agent.tools.GmailToolkit", return_value=fake_gmail):
+        tools = agent_tools.build_gmail_tools()
+    dumped = tools[0].model_dump()
+    assert "token" not in json.dumps(dumped)
+    assert "api_resource" not in dumped


### PR DESCRIPTION
## Summary
- add `agent/tools.py` with Gmail/Calendar toolkit builders
- use new helpers in `src/tool_agent.py` and `agent/nodes.py`
- unit tests for new tools module
- update tool agent tests for new import path

## Testing
- `pytest -q tests/test_bootstrap.py tests/test_embedding_pipeline.py tests/test_graph.py tests/test_hitl_flow.py tests/test_ingestion.py tests/test_llm_providers.py tests/test_meta_agent.py tests/test_meta_agent_integration.py tests/test_minimal_agent.py tests/test_nodes.py tests/test_onboard.py tests/test_pkg_schema.py tests/test_prioritise.py tests/test_qdrant_migration.py tests/test_rag_agent.py tests/test_task_api.py tests/test_tasks_db.py tests/test_token_counter.py tests/test_tool_agent.py tests/test_tools.py`

------
https://chatgpt.com/codex/tasks/task_e_6859ceecd89c832aa7c84fe2016cf558