### PR TITLE
Add quick links to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,16 @@ cd apps/graph-inspector && yarn dev  # live LangGraph viewer
 
 > **Tip:** first launch downloads base Ollama model (~3 GB). Subsequent runs are instant.
 
+## 🔗 Quick Links
+
+| Resource | How to access |
+|----------|---------------|
+| **Langfuse dashboard** | <http://localhost:3000> |
+| **Docs site** | `make docserve` → <http://127.0.0.1:8000> |
+| **Graph inspector** | `cd apps/graph-inspector && yarn dev` → <http://localhost:5173> |
+| **Run the agent** | `python src/minimal_agent.py "Hello"` |
+| **Health check** | `python scripts/healthcheck.py` |
+
 ---
 
 ## 🗺 System Architecture

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,5 +1,15 @@
 # Personal Agentic OS
 
-Welcome! This site mirrors key docs from the repo. For a quick overview, see the README below.
+Welcome! This site mirrors key docs from the repo.
+
+## Quick Links
+
+| Resource | How to access |
+|----------|---------------|
+| **Langfuse dashboard** | <http://localhost:3000> |
+| **Docs site** | `make docserve` → <http://127.0.0.1:8000> |
+| **Graph inspector** | `cd apps/graph-inspector && yarn dev` → <http://localhost:5173> |
+| **Run the agent** | `python src/minimal_agent.py "Hello"` |
+| **Health check** | `python scripts/healthcheck.py` |
 
 !include ../README.md


### PR DESCRIPTION
## Summary
- add Quick Links section to README
- expose same links on docs home page

## Testing
- `make test` *(fails: Docker connection error)*

------
https://chatgpt.com/codex/tasks/task_e_6859d573e5c0832ab0d836b629fb75b8