### PR TITLE
Fix ClickHouse startup and migration URL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,6 +10,7 @@ NEXTAUTH_SECRET=0123456789abcdef0123456789abcdef
 SALT=fedcba9876543210fedcba9876543210
 DATABASE_URL=postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres/${POSTGRES_DB}
 CLICKHOUSE_URL=http://clickhouse:8123
+CLICKHOUSE_MIGRATION_URL=http://default:langfuse@clickhouse:8123/langfuse
 CLICKHOUSE_PASSWORD=changeme
 
 # === Google API ===

--- a/clickhouse-mutation-pool.xml
+++ b/clickhouse-mutation-pool.xml
@@ -1,0 +1,5 @@
+<yandex>
+  <merge_tree>
+    <number_of_free_entries_in_pool_to_execute_mutation>8</number_of_free_entries_in_pool_to_execute_mutation>
+  </merge_tree>
+</yandex>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,7 @@ services:
       NEXTAUTH_SECRET: ${NEXTAUTH_SECRET}
       SALT: ${SALT}
       CLICKHOUSE_URL: ${CLICKHOUSE_URL:-}
+      CLICKHOUSE_MIGRATION_URL: ${CLICKHOUSE_MIGRATION_URL:-}
       # keys injected via .env
     # If CLICKHOUSE_URL is empty, onboard.py patches LANGFUSE_IMAGE to 2.58.0-arm64 automatically.
     networks: ["agentnet"]
@@ -50,6 +51,7 @@ services:
       - ./data/clickhouse:/var/lib/clickhouse
       - ./logs/clickhouse:/var/log/clickhouse-server
       - ./docker/clickhouse/config.xml:/etc/clickhouse-server/config.d/dev-overrides.xml:ro
+      - ./clickhouse-mutation-pool.xml:/etc/clickhouse-server/config.d/10-mutation-pool.xml:ro
     networks: ["agentnet"]
   neo4j:
     image: neo4j:5.20


### PR DESCRIPTION
## Summary
- set `CLICKHOUSE_MIGRATION_URL` in `.env.example`
- pass `CLICKHOUSE_MIGRATION_URL` to Langfuse container
- add ClickHouse mutation pool override and mount it

## Testing
- `make test` *(fails: tests require Docker which isn't available)*

------
https://chatgpt.com/codex/tasks/task_e_6859d750c5c8832ab9646265ed3626bb