### PR TITLE
Add updated_at timestamps to tasks

### DIFF
--- a/agent/tasks_db.py
+++ b/agent/tasks_db.py
@@ -18,7 +18,13 @@ def init_db() -> None:
     os.makedirs("data", exist_ok=True)
     conn = sqlite3.connect(DB_PATH)
     conn.execute(
-        "CREATE TABLE IF NOT EXISTS tasks (task_id TEXT PRIMARY KEY, data TEXT)"
+        """
+        CREATE TABLE IF NOT EXISTS tasks (
+            task_id TEXT PRIMARY KEY,
+            data TEXT,
+            updated_at TEXT DEFAULT CURRENT_TIMESTAMP
+        )
+        """
     )
     conn.commit()
     conn.close()
@@ -30,7 +36,7 @@ init_db()
 def add_task(task: Dict[str, Any]) -> None:
     conn = sqlite3.connect(DB_PATH)
     conn.execute(
-        "INSERT OR REPLACE INTO tasks (task_id, data) VALUES (?, ?)",
+        "INSERT OR REPLACE INTO tasks (task_id, data, updated_at) VALUES (?, ?, CURRENT_TIMESTAMP)",
         (task["task_id"], json.dumps(task)),
     )
     conn.commit()

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -2,7 +2,7 @@ def test_build_graph(monkeypatch, tmp_path):
     import agent.graph as g
     monkeypatch.setattr(g, "HITL_DIR", tmp_path / "queue")
     # avoid writing image file
-    from langgraph.graph import Graph
+    from langgraph.graph import StateGraph as Graph
     monkeypatch.setattr(
         Graph,
         "draw_mermaid_png",


### PR DESCRIPTION
## Summary
- track `updated_at` for tasks in SQLite
- store `updated_at` when adding tasks
- skip ClickHouse tests if docker is unavailable
- update graph test import for current langgraph API
- verify timestamp handling in `test_tasks_db`

## Testing
- `ruff check .`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_687f230bef44832ab745158cad67f638