### PR TITLE
Add filtering to task API

### DIFF
--- a/src/task_api.py
+++ b/src/task_api.py
@@ -5,8 +5,14 @@ app = FastAPI()
 
 
 @app.get("/tasks")
-def list_tasks():
-    return tasks_db.list_tasks()
+def list_tasks(status: str | None = None, priority: str | None = None):
+    """Return tasks filtered by optional status and priority."""
+    tasks = tasks_db.list_tasks()
+    if status:
+        tasks = [t for t in tasks if t.get("status") == status]
+    if priority:
+        tasks = [t for t in tasks if t.get("priority") == priority]
+    return tasks
 
 
 @app.post("/tasks/{task_id}/approve")

--- a/tests/test_task_api.py
+++ b/tests/test_task_api.py
@@ -50,3 +50,17 @@ def test_approve_and_cancel(tmp_path, monkeypatch):
     assert resp.status_code == 200
     updated = tasks_db.get_task("2")
     assert updated["status"] == "CANCELLED"
+
+
+def test_list_tasks_filtered(tmp_path, monkeypatch):
+    setup_temp_db(tmp_path, monkeypatch)
+    tasks_db.add_task({"task_id": "1", "objective": "demo", "status": "NEW", "priority": "low"})
+    tasks_db.add_task({"task_id": "2", "objective": "demo2", "status": "DONE", "priority": "high"})
+    client = TestClient(api.app)
+    resp = client.get("/tasks", params={"status": "DONE"})
+    assert resp.status_code == 200
+    assert [t["task_id"] for t in resp.json()] == ["2"]
+
+    resp = client.get("/tasks", params={"priority": "low"})
+    assert resp.status_code == 200
+    assert [t["task_id"] for t in resp.json()] == ["1"]


### PR DESCRIPTION
## Summary
- allow `/tasks` endpoint to filter tasks by `status` and `priority`
- test that filters return the expected tasks

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_687f27b3e948832aa320c9fdc4361100