### PR TITLE
Expose retrieval metadata

### DIFF
--- a/agent/nodes.py
+++ b/agent/nodes.py
@@ -46,10 +46,11 @@ def retrieve_context(state: AgentState) -> Dict[str, Any]:
     query = state["messages"][-1].content
     _, meta = query_pkg(query)
     entities = [m["entity"] for m in meta if "entity" in m]
-    docs = filter_qdrant_by_entities(query, entities)
+    docs, rmeta = filter_qdrant_by_entities(query, entities)
     return {
         "context_docs": [d.page_content for d in docs],
         "graph_metadata": meta,
+        "retrieval_meta": rmeta,
     }
 
 

--- a/agent/retrieve_context.py
+++ b/agent/retrieve_context.py
@@ -73,8 +73,9 @@ retriever = _build_retriever()
 # --- Qdrant Filtering -------------------------------------------------------
 
 
-def filter_qdrant_by_entities(query: str, entities: List[str]) -> List[Document]:
+def filter_qdrant_by_entities(query: str, entities: List[str]) -> tuple[List[Document], dict]:
     """Return documents matching the query and entity metadata."""
+    pkg_matches = len(entities)
     if entities:
         filter_ = {"must": [{"key": "entities", "match": {"any": entities}}]}
         docs = retriever.invoke(query, search_kwargs={"filter": filter_})
@@ -83,4 +84,8 @@ def filter_qdrant_by_entities(query: str, entities: List[str]) -> List[Document]
             docs = retriever.invoke(query)
     else:
         docs = retriever.invoke(query)
-    return docs
+    result_count = len(docs)
+    logging.info(
+        "filter_qdrant_by_entities: %d pkg matches -> %d docs", pkg_matches, result_count
+    )
+    return docs, {"pkg_match_count": pkg_matches, "doc_count": result_count}

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -70,6 +70,7 @@ def test_retrieve_context_returns_metadata():
         out = nodes.retrieve_context(state)
     assert out["context_docs"] == ["hi"]
     assert out["graph_metadata"] == [{"doc_id": "1", "entity": "Alice"}]
+    assert out["retrieval_meta"] == {"pkg_match_count": 1, "doc_count": 1}
 
 
 def test_retrieve_context_filters_entities():
@@ -100,6 +101,7 @@ def test_retrieve_context_filters_entities():
         out = nodes.retrieve_context(state)
 
     assert out["context_docs"] == ["alice"]
+    assert out["retrieval_meta"] == {"pkg_match_count": 1, "doc_count": 1}
 
 
 def test_filter_qdrant_fallback():
@@ -112,11 +114,13 @@ def test_filter_qdrant_fallback():
     fake_retriever.invoke.side_effect = [[], [doc]]
 
     with patch.object(rc, "retriever", fake_retriever), patch.object(rc, "logging") as lg:
-        docs = rc.filter_qdrant_by_entities("hello", ["Alice"])
+        docs, meta = rc.filter_qdrant_by_entities("hello", ["Alice"])
 
     assert docs == [doc]
+    assert meta == {"pkg_match_count": 1, "doc_count": 1}
     assert fake_retriever.invoke.call_count == 2
     assert lg.warning.called
+    assert "falling back" in lg.warning.call_args[0][0]
 
 
 def test_prioritise_applies_rules():


### PR DESCRIPTION
## Summary
- log entity vs doc counts in `filter_qdrant_by_entities`
- return these counts to calling nodes
- adapt retrieval node and tests

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_687f704ff198832a89b55b4b491a0e7b