### PR TITLE
Add graph layout endpoint and fetch in inspector

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ cd personal-agentic-operating-system
 make ingest                    # populate Qdrant & PKG
 python src/minimal_agent.py "Summarise my inbox"
 make task-api                   # optional REST interface
+uvicorn trace_agent.main:app --reload &  # start SSE backend
 cd apps/graph-inspector && yarn dev  # live LangGraph viewer
 bash scripts/check_db_connections.sh  # verify database access
 ```
@@ -45,7 +46,7 @@ bash scripts/check_db_connections.sh  # verify database access
 |----------|---------------|
 | **Langfuse dashboard** | <http://localhost:3000> |
 | **Docs site** | `make docserve` → <http://127.0.0.1:8000> |
-| **Graph inspector** | `cd apps/graph-inspector && yarn dev` → <http://localhost:5173> |
+| **Graph inspector** | `uvicorn trace_agent.main:app --reload` + `cd apps/graph-inspector && yarn dev` → <http://localhost:5173> |
 | **Run the agent** | `python src/minimal_agent.py "Hello"` |
 | **Health check** | `python scripts/healthcheck.py` |
 
@@ -125,7 +126,7 @@ Site-rendered docs: <https://adrianwedd.github.io/personal-agentic-operating-sys
 | `make graph`| Render Mermaid PNG of current LangGraph |
 | `make docserve`| Hot-reload MkDocs at <http://127.0.0.1:8000> |
 | `make task-api`| Launch FastAPI task API |
-| `yarn dev` (apps/graph-inspector)| Live graph inspector UI |
+| `yarn dev` (apps/graph-inspector)| Live graph inspector UI (requires `uvicorn trace_agent.main:app`) |
 
 ## 🔄 Meta-agent Schedule
 

--- a/agent/graph.py
+++ b/agent/graph.py
@@ -76,6 +76,34 @@ def build_graph() -> any:
 compiled_graph = build_graph()
 
 
+def graph_layout() -> dict:
+    """Return nodes and edges suitable for ReactFlow."""
+    graph = compiled_graph.get_graph()
+    nodes = []
+    x = 0
+    for node in graph.nodes:
+        if node in {"__start__", "__end__"}:
+            continue
+        nodes.append({
+            "id": node,
+            "position": {"x": x, "y": 0},
+            "data": {"label": node},
+        })
+        x += 150
+
+    edges = []
+    for edge in graph.edges:
+        if edge.source in {"__start__", "__end__"} or edge.target in {"__start__", "__end__"}:
+            continue
+        edges.append({
+            "id": f"{edge.source}-{edge.target}",
+            "source": edge.source,
+            "target": edge.target,
+        })
+
+    return {"nodes": nodes, "edges": edges}
+
+
 def main(prompt: str) -> None:
     state: AgentState = {"messages": [HumanMessage(content=prompt)], "tasks": [], "context_docs": [], "current_task": None}
     langfuse = Langfuse()

--- a/apps/graph-inspector/src/App.tsx
+++ b/apps/graph-inspector/src/App.tsx
@@ -2,23 +2,18 @@ import React, { useEffect, useState } from 'react';
 import ReactFlow, { Node, Edge } from 'reactflow';
 import 'reactflow/dist/style.css';
 
-const initialNodes: Node[] = [
-  { id: 'plan', position: { x: 0, y: 0 }, data: { label: 'plan' } },
-  { id: 'prioritise', position: { x: 150, y: 0 }, data: { label: 'prioritise' } },
-  { id: 'retrieve', position: { x: 300, y: 0 }, data: { label: 'retrieve' } },
-  { id: 'execute', position: { x: 450, y: 0 }, data: { label: 'execute' } },
-  { id: 'respond', position: { x: 600, y: 0 }, data: { label: 'respond' } }
-];
-
-const edges: Edge[] = [
-  { id: 'e1', source: 'plan', target: 'prioritise' },
-  { id: 'e2', source: 'prioritise', target: 'retrieve' },
-  { id: 'e3', source: 'retrieve', target: 'execute' },
-  { id: 'e4', source: 'execute', target: 'respond' }
-];
-
 export default function App() {
-  const [nodes, setNodes] = useState<Node[]>(initialNodes);
+  const [nodes, setNodes] = useState<Node[]>([]);
+  const [edges, setEdges] = useState<Edge[]>([]);
+
+  useEffect(() => {
+    fetch('/graph-layout')
+      .then((res) => res.json())
+      .then((data) => {
+        setNodes(data.nodes);
+        setEdges(data.edges);
+      });
+  }, []);
 
   useEffect(() => {
     const es = new EventSource('/graph-events');

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -14,3 +14,13 @@ def test_build_graph(monkeypatch, tmp_path):
     assert "prioritise" in nodes
     edges = {(e.source, e.target) for e in compiled.get_graph().edges}
     assert ("execute", "pause") in edges
+
+
+def test_graph_layout():
+    from agent.graph import graph_layout
+
+    layout = graph_layout()
+    node_ids = {n["id"] for n in layout["nodes"]}
+    assert "plan" in node_ids
+    edge_pairs = {(e["source"], e["target"]) for e in layout["edges"]}
+    assert ("plan", "prioritise") in edge_pairs

--- a/trace_agent/main.py
+++ b/trace_agent/main.py
@@ -2,6 +2,7 @@ from fastapi import FastAPI
 from fastapi.responses import StreamingResponse
 import json
 from .event_broker import broker
+from agent.graph import graph_layout
 
 app = FastAPI()
 
@@ -19,3 +20,8 @@ async def graph_events() -> StreamingResponse:
             broker.unregister(queue)
 
     return StreamingResponse(event_stream(), media_type="text/event-stream")
+
+
+@app.get("/graph-layout")
+async def get_graph_layout() -> dict:
+    return graph_layout()


### PR DESCRIPTION
## Summary
- add `graph_layout()` helper in `agent.graph`
- expose `/graph-layout` endpoint via FastAPI
- fetch node layout on startup in React inspector
- document inspector startup in README
- test new layout helper

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687f90473050832abbd65d6006b2efc4