### PR TITLE
Log meta-agent updates

### DIFF
--- a/docs/guides/meta_agent.md
+++ b/docs/guides/meta_agent.md
@@ -1,0 +1,5 @@
+# Meta-Agent
+
+The meta-agent analyses reflection logs and rewrites `guidelines.txt`.
+Each run also appends the new guideline text with a timestamp to
+`logs/meta_agent.log`.

--- a/scripts/run_meta_agent.py
+++ b/scripts/run_meta_agent.py
@@ -1,9 +1,49 @@
-"""Run the meta-agent to update guidelines."""
+"""Run the meta-agent to update guidelines and manage its log."""
+
+from __future__ import annotations
+
+import os
+from datetime import datetime
 
 from agent.meta_agent import run_meta_agent
 
+LOG_FILE = "logs/meta_agent.log"
 
-if __name__ == "__main__":
+
+def _append_log(text: str) -> None:
+    os.makedirs(os.path.dirname(LOG_FILE), exist_ok=True)
+    with open(LOG_FILE, "a") as fh:
+        fh.write(f"{datetime.utcnow().isoformat()} {text}\n")
+
+
+def _last_update() -> str | None:
+    try:
+        with open(LOG_FILE) as fh:
+            lines = fh.read().splitlines()
+        return lines[-1] if lines else None
+    except FileNotFoundError:
+        return None
+
+
+def main(show_last: bool = False) -> None:
+    if show_last:
+        last = _last_update()
+        print(last or "No updates yet")
+        return
     result = run_meta_agent()
     if result:
         print(result)
+        _append_log(result)
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Run the meta-agent")
+    parser.add_argument(
+        "--show-last",
+        action="store_true",
+        help="Display the most recent guideline update",
+    )
+    args = parser.parse_args()
+    main(show_last=args.show_last)

--- a/tests/test_run_meta_agent.py
+++ b/tests/test_run_meta_agent.py
@@ -1,0 +1,33 @@
+import os, sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from unittest.mock import patch
+import scripts.run_meta_agent as rma
+
+
+def test_append_log(tmp_path):
+    rma.LOG_FILE = str(tmp_path / "meta.log")
+    rma._append_log("hello")
+    assert os.path.exists(rma.LOG_FILE)
+    with open(rma.LOG_FILE) as fh:
+        line = fh.read().strip()
+    assert "hello" in line
+
+
+def test_main_show_last(capsys, tmp_path):
+    rma.LOG_FILE = str(tmp_path / "meta.log")
+    with open(rma.LOG_FILE, "w") as fh:
+        fh.write("2024-01-01 foo\n2024-01-02 bar\n")
+    rma.main(show_last=True)
+    captured = capsys.readouterr()
+    assert "bar" in captured.out
+
+
+def test_main_runs_and_logs(tmp_path):
+    rma.LOG_FILE = str(tmp_path / "meta.log")
+    with patch("scripts.run_meta_agent.run_meta_agent", return_value="new rule"):
+        rma.main()
+    with open(rma.LOG_FILE) as fh:
+        data = fh.read()
+    assert "new rule" in data
+


### PR DESCRIPTION
## Summary
- log meta-agent guideline updates with timestamp
- support `--show-last` to print the most recent log entry
- note log location in new meta agent guide
- test the new logging functions

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_687f9df8f11c832aa2783a0be690e9d9