### PR TITLE
Introduce QDRANT_COLLECTION env var

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,6 +23,10 @@ CLICKHOUSE_URL=http://clickhouse:8123
 # Native TCP endpoint for the migration step (must be a full ClickHouse URL).
 CLICKHOUSE_MIGRATION_URL=clickhouse://clickhouse:02c1fbbfdcd12664@clickhouse:9000/langfuse?compression=lz4
 
+##### Qdrant container #######################################################
+# Default collection used for ingestion and retrieval
+QDRANT_COLLECTION=ingestion
+
 ###############################################################################
 #                               LANGFUSE                                      #
 ###############################################################################

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ git clone https://github.com/adrianwedd/personal-agentic-operating-system.git
 cd personal-agentic-operating-system
 ./bootstrap.sh                  # 🚀 zero-click setup wizard
 make ingest                    # populate Qdrant & PKG
+# export QDRANT_COLLECTION=my_collection to change the target
 python src/minimal_agent.py "Summarise my inbox"
 make task-api                   # optional REST interface
 uvicorn trace_agent.main:app --reload &  # start SSE backend

--- a/agent/retrieve_context.py
+++ b/agent/retrieve_context.py
@@ -58,10 +58,11 @@ def query_pkg(query: str) -> Tuple[List[str], List[dict]]:
 
 
 def _build_retriever() -> any:
+    collection = os.environ.get("QDRANT_COLLECTION", "ingestion")
     client = QdrantClient(url=os.environ.get("QDRANT_URL", "http://localhost:6333"))
     vectorstore = Qdrant(
         client=client,
-        collection_name="ingestion",
+        collection_name=collection,
         embeddings=OllamaEmbeddings(),
     )
     return vectorstore.as_retriever()

--- a/ingestion/ingest.py
+++ b/ingestion/ingest.py
@@ -45,10 +45,11 @@ def ingest(gmail_query: str | None = None, directory: str | None = None) -> None
 
     embeddings = OllamaEmbeddings()
     client = QdrantClient(url=os.environ.get("QDRANT_URL", "http://localhost:6333"))
-    vectorstore = Qdrant(client=client, collection_name="ingestion", embeddings=embeddings)
+    collection = os.environ.get("QDRANT_COLLECTION", "ingestion")
+    vectorstore = Qdrant(client=client, collection_name=collection, embeddings=embeddings)
 
     ids = vectorstore.add_texts(texts, metadatas=metas)
-    print(f"Stored {len(ids)} chunks in Qdrant collection 'ingestion'")
+    print(f"Stored {len(ids)} chunks in Qdrant collection '{collection}'")
 
 
 if __name__ == "__main__":

--- a/src/rag_agent.py
+++ b/src/rag_agent.py
@@ -28,9 +28,10 @@ class AgentState(TypedDict):
 def _build_retriever() -> any:
     """Create a Qdrant hybrid retriever."""
     client = QdrantClient(url=os.environ.get("QDRANT_URL", "http://localhost:6333"))
+    collection = os.environ.get("QDRANT_COLLECTION", "ingestion")
     vectorstore = Qdrant(
         client=client,
-        collection_name="ingestion",
+        collection_name=collection,
         embeddings=OllamaEmbeddings(),
     )
     return vectorstore.as_retriever()


### PR DESCRIPTION
## Summary
- make the Qdrant collection name configurable via `QDRANT_COLLECTION`
- respect the variable in retrievers and ingestion
- document the new option in `.env.example` and quickstart

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_687fa6bdccbc832aa1bf26d8ba94196c