### PR TITLE
Add meta-agent usage docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,16 @@ Run `scripts/run_meta_agent.py` daily so the system can refine
 
 Systemd users can create a timer that calls the same script once per day.
 
+View the latest guidelines with:
+
+```bash
+python scripts/run_meta_agent.py --show-last
+# or
+cat guidelines.txt
+```
+
+For more details see [guides/meta_agent.md](docs/guides/meta_agent.md).
+
 ---
 
 ## 🏗 Contributing

--- a/docs/guides/meta_agent.md
+++ b/docs/guides/meta_agent.md
@@ -1,5 +1,29 @@
 # Meta-Agent
 
-The meta-agent analyses reflection logs and rewrites `guidelines.txt`.
-Each run also appends the new guideline text with a timestamp to
-`logs/meta_agent.log`.
+The meta-agent closes the self-improvement loop. It scans the
+`reflections_log` collection in Qdrant and asks the default LLM to
+summarise recent entries into a concise set of guidelines. The result is
+written to `guidelines.txt` in the repository root and the text is also
+appended to `logs/meta_agent.log` with a timestamp.
+
+Run the agent manually with:
+
+```bash
+python scripts/run_meta_agent.py
+```
+
+To inspect the most recent update without generating a new one use the
+`--show-last` flag or simply read `guidelines.txt`:
+
+```bash
+python scripts/run_meta_agent.py --show-last
+cat guidelines.txt
+```
+
+Automate daily runs using cron:
+
+```cron
+0 3 * * * /usr/bin/python /path/to/scripts/run_meta_agent.py >> ~/meta.log 2>&1
+```
+
+Systemd users can create a timer invoking the same script once per day.

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,4 +12,7 @@ Welcome! This site mirrors key docs from the repo.
 | **Run the agent** | `python src/minimal_agent.py "Hello"` |
 | **Health check** | `python scripts/healthcheck.py` |
 
+See [Guidelines and the meta-agent](guides/meta_agent.md) for details on the
+self-improvement loop.
+
 !include ../README.md


### PR DESCRIPTION
## Summary
- expand meta-agent guide with cron scheduling and how to check guidelines
- link the meta-agent docs from README and docs index

## Testing
- `make test`
- `make docbuild`


------
https://chatgpt.com/codex/tasks/task_e_687fa8b5a74c832a965cf565ce6a16bc