### PR TITLE
Log events to JSONL with rotation

### DIFF
--- a/tests/test_event_broker.py
+++ b/tests/test_event_broker.py
@@ -1,0 +1,42 @@
+import json
+from pathlib import Path
+from unittest.mock import mock_open, MagicMock
+
+import trace_agent.event_broker as eb
+
+
+def test_emit_writes_json_line(monkeypatch):
+    broker = eb.EventBroker()
+    m = mock_open()
+    monkeypatch.setattr("builtins.open", m)
+    path = Path("dummy.jsonl")
+    monkeypatch.setattr(eb, "LOG_FILE", path)
+    monkeypatch.setattr(Path, "mkdir", lambda self, parents=False, exist_ok=False: None)
+    monkeypatch.setattr(Path, "exists", lambda self: False)
+    monkeypatch.setattr(Path, "stat", lambda self: type("S", (), {"st_size": 0})())
+
+    broker.emit({"a": 1})
+
+    m.assert_called_once_with(path, "a")
+    handle = m()
+    handle.write.assert_called_once_with(json.dumps({"a": 1}, ensure_ascii=False) + "\n")
+
+
+def test_emit_rotates_when_large(monkeypatch):
+    broker = eb.EventBroker()
+    m = mock_open()
+    path = Path("dummy.jsonl")
+    monkeypatch.setattr("builtins.open", m)
+    monkeypatch.setattr(eb, "LOG_FILE", path)
+    monkeypatch.setattr(eb, "ROTATE_SIZE", 10)
+    monkeypatch.setattr(Path, "mkdir", lambda self, parents=False, exist_ok=False: None)
+    monkeypatch.setattr(Path, "exists", lambda self: True)
+    monkeypatch.setattr(Path, "stat", lambda self: type("S", (), {"st_size": 20})())
+    rename_mock = MagicMock()
+    monkeypatch.setattr(Path, "rename", lambda self, dst: rename_mock(dst))
+
+    broker.emit({"b": 2})
+
+    assert rename_mock.called
+    handle = m()
+    handle.write.assert_called_once()

--- a/trace_agent/event_broker.py
+++ b/trace_agent/event_broker.py
@@ -1,6 +1,13 @@
 from __future__ import annotations
 import asyncio
+import json
+from datetime import datetime
+from pathlib import Path
 from typing import Any, Set
+
+
+LOG_FILE = Path("logs/trace_events.jsonl")
+ROTATE_SIZE = 5 * 1024 * 1024  # 5MB
 
 
 class EventBroker:
@@ -18,6 +25,18 @@ class EventBroker:
     def emit(self, event: dict) -> None:
         for listener in list(self.listeners):
             listener.put_nowait(event)
+        self._write_event(event)
+
+    def _write_event(self, event: dict) -> None:
+        path = LOG_FILE
+        path.parent.mkdir(parents=True, exist_ok=True)
+        line = json.dumps(event, ensure_ascii=False)
+        if path.exists() and path.stat().st_size + len(line) + 1 > ROTATE_SIZE:
+            ts = datetime.utcnow().strftime("%Y%m%d%H%M%S")
+            rotated = path.with_name(f"{path.stem}_{ts}{path.suffix}")
+            path.rename(rotated)
+        with open(path, "a") as fh:
+            fh.write(line + "\n")
 
 
 broker = EventBroker()


### PR DESCRIPTION
## Summary
- log all emitted events to `logs/trace_events.jsonl`
- rotate the trace log when it grows beyond a size limit
- add unit tests for new logging behaviour using mocked file I/O

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687faa7aebb4832abc9beab655c629d0