### PR TITLE
Switch AgentState to dataclass

### DIFF
--- a/agent/graph.py
+++ b/agent/graph.py
@@ -32,7 +32,7 @@ def human_approval(state: AgentState) -> dict:
         return {}
     path = os.path.join(HITL_DIR, f"{task['task_id']}.json")
     with open(path, "w") as fh:
-        json.dump(state, fh)
+        json.dump(state.to_dict(), fh)
     return {}
 
 
@@ -105,7 +105,12 @@ def graph_layout() -> dict:
 
 
 def main(prompt: str) -> None:
-    state: AgentState = {"messages": [HumanMessage(content=prompt)], "tasks": [], "context_docs": [], "current_task": None}
+    state = AgentState(
+        messages=[HumanMessage(content=prompt)],
+        tasks=[],
+        context_docs=[],
+        current_task=None,
+    )
     langfuse = Langfuse()
     handler = CallbackHandler(langfuse)
     result = compiled_graph.invoke(state, config={"callbacks": [handler]})

--- a/agent/state.py
+++ b/agent/state.py
@@ -1,14 +1,32 @@
 from __future__ import annotations
 
-from typing import TypedDict, List, Dict, Any
+from dataclasses import dataclass, field, asdict
+from typing import List, Dict, Any, Optional
 from langchain_core.messages import BaseMessage
 
 
-class AgentState(TypedDict, total=False):
+@dataclass
+class AgentState:
     """Shared agent state for LangGraph."""
 
-    messages: List[BaseMessage]
-    tasks: List[Dict[str, Any]]
-    current_task: Dict[str, Any] | None
-    tool_output: str | None
-    context_docs: List[str]
+    messages: List[BaseMessage] = field(default_factory=list)
+    tasks: List[Dict[str, Any]] = field(default_factory=list)
+    current_task: Optional[Dict[str, Any]] = None
+    tool_output: Optional[str] = None
+    context_docs: List[str] = field(default_factory=list)
+
+    def __getitem__(self, key: str) -> Any:
+        return getattr(self, key)
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        setattr(self, key, value)
+
+    def get(self, key: str, default: Any = None) -> Any:
+        return getattr(self, key, default)
+
+    def update(self, other: Dict[str, Any]) -> None:
+        for k, v in other.items():
+            setattr(self, k, v)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -2,6 +2,7 @@ def test_human_approval(tmp_path):
     from agent import graph
 
     graph.HITL_DIR = tmp_path
-    state = {"current_task": {"task_id": "t1"}}
+    from agent.state import AgentState
+    state = AgentState(current_task={"task_id": "t1"})
     graph.human_approval(state)
     assert (tmp_path / "t1.json").exists()

--- a/tests/test_rag_agent.py
+++ b/tests/test_rag_agent.py
@@ -9,7 +9,8 @@ from langchain_core.documents import Document
 
 
 def test_retrieve_context():
-    state = {"messages": [HumanMessage(content="foo")], "context_docs": []}
+    from rag_agent import AgentState
+    state = AgentState(messages=[HumanMessage(content="foo")], context_docs=[])
     fake_doc = Document(page_content="bar")
     fake_retriever = MagicMock()
     fake_retriever.invoke.return_value = [fake_doc]
@@ -19,7 +20,8 @@ def test_retrieve_context():
 
 
 def test_answer_step():
-    state = {"messages": [HumanMessage(content="hi")], "context_docs": ["ctx"]}
+    from rag_agent import AgentState
+    state = AgentState(messages=[HumanMessage(content="hi")], context_docs=["ctx"])
     fake_llm = MagicMock()
     fake_llm.chat.return_value = AIMessage(content="pong")
     with patch("rag_agent.get_default_client", return_value=fake_llm):

--- a/tests/test_rag_tool_integration.py
+++ b/tests/test_rag_tool_integration.py
@@ -26,7 +26,8 @@ def test_rag_to_tool_flow(capsys):
         assert vs.add_texts.called
 
     # Retrieve the document via rag_agent
-    state = {"messages": [HumanMessage(content="where is the sample?" )], "context_docs": []}
+    from rag_agent import AgentState
+    state = AgentState(messages=[HumanMessage(content="where is the sample?")], context_docs=[])
     fake_retriever = MagicMock()
     fake_retriever.invoke.return_value = [Document(page_content=doc_text)]
     with patch("rag_agent.retriever", fake_retriever):
@@ -36,7 +37,7 @@ def test_rag_to_tool_flow(capsys):
     fake_llm = MagicMock()
     fake_llm.chat.return_value = AIMessage(content="answer")
     with patch("rag_agent.get_default_client", return_value=fake_llm):
-        rag_agent.answer_step({**state, "context_docs": ctx["context_docs"]})
+        rag_agent.answer_step(AgentState(messages=state["messages"], context_docs=ctx["context_docs"]))
 
     # Execute a simple tool using tool_agent
     fake_agent = MagicMock()


### PR DESCRIPTION
## Summary
- replace `TypedDict` with `@dataclass` implementation of `AgentState`
- update graph and rag agent to create dataclass instances
- dump dataclass state for HITL queue
- update tests to instantiate new dataclass

## Testing
- `make ruff`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68801ba54f6c832a8f046fbecb948cc2